### PR TITLE
Add mtime= URL parameter to local JS and CSS.

### DIFF
--- a/app/lib/ca/JavascriptLoadManager.php
+++ b/app/lib/ca/JavascriptLoadManager.php
@@ -154,6 +154,10 @@
 						$vs_url = $va_matches[1];
 					} else {
 						$vs_url = "{$ps_baseurlpath}/js/{$vs_lib}";
+						$vs_filename = __CA_BASE_DIR__ . $vs_url;
+						if (file_exists($vs_filename)) {
+							$vs_url .= '?mtime=' . filemtime($vs_filename);
+						}
 					}
 					
 					if (preg_match('!\.css$!', $vs_lib)) {


### PR DESCRIPTION
For local files, use filemtime() to grab the modification time
of the file and append it as a URL parameter.  This causes browsers
to cache the file until it is modified.  These files can therefore
be configured to be cached forever by the browser, as any modifications
will be automatically retrieved as there will be a new URL whenever the
file is modified.
