### PR TITLE
Remove specific title generator plugin config.

### DIFF
--- a/app/plugins/wamTitleGenerator/conf/wamTitleGenerator.conf
+++ b/app/plugins/wamTitleGenerator/conf/wamTitleGenerator.conf
@@ -1,18 +1,6 @@
 # Load plugin?
 enabled = 1
-#specify the format to use for the title
-# see http://docs.collectiveaccess.org/wiki/Configuration_File_Syntax
-title_formatters = {
-	ca_objects = {
-		arachnid_myriapod = {
-			name = ^ca_collections ^ca_objects.idno <em>^ca_list_items</em> ^ca_entities
-		}
-	},
-	ca_list_items = {
-		scientific_name = {
-			name_singular = <em title="^ca_list_items.taxonRank">^ca_list_items.idno</em> <ifdef code="parentheticalAuthor">(</ifdef>^ca_entities ^ca_list_items.namePublishedInYear<ifdef code="parentheticalAuthor">)</ifdef>,
-			name_plural = <em title="^ca_list_items.taxonRank">^ca_list_items.idno</em> <ifdef code="parentheticalAuthor">(</ifdef>^ca_entities ^ca_list_items.namePublishedInYear<ifdef code="parentheticalAuthor">)</ifdef>
-		}
-	}
 
+# Specify the format to use for the title, per record type
+title_formatters = {
 }


### PR DESCRIPTION
This is now in cmis-local-conf project.
Base configuration now just enables plugin and specifies no title_formatters.
