### PR TITLE
Remove unused method.

### DIFF
--- a/support/tests/plugins/AbstractPluginIntegrationTest.php
+++ b/support/tests/plugins/AbstractPluginIntegrationTest.php
@@ -138,15 +138,6 @@ abstract class AbstractPluginIntegrationTest extends PHPUnit_Framework_TestCase 
 	}
 
 	/**
-	 * Get the directory where the plugin config for the test should be loaded from.
-	 * @return string
-	 * @throws Exception
-	 */
-	protected static function _getConfigurationDirectory() {
-		throw new Exception('not implemented');
-	}
-
-	/**
 	 * Convert the configuration file template containing placeholders into a ready-to-use configuration file
 	 * containing generated idno values.
 	 * @param $ps_dir

--- a/support/tests/plugins/relationshipGenerator/RelationshipGeneratorPluginIntegrationTest.php
+++ b/support/tests/plugins/relationshipGenerator/RelationshipGeneratorPluginIntegrationTest.php
@@ -72,10 +72,6 @@ class RelationshipGeneratorPluginIntegrationTest extends AbstractPluginIntegrati
 		self::_cleanup();
 	}
 
-	protected static function _getConfigurationDirectory() {
-		return __DIR__ . '/conf/integration';
-	}
-
 	public function testInsertedRecordNotMatchingAnyRule() {
 		$vo_object = self::_createObject('notMatchingAnyRule', array( 'element1' => 'this value matches nothing' ));
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection1'), 'Object does not have a relationship with collection1');


### PR DESCRIPTION
This method was added during development but not used, accidentally left in for previous commit.
