### PR TITLE
Allow caUtils to specify alternate setup.php

### DIFF
--- a/support/bin/caUtils
+++ b/support/bin/caUtils
@@ -76,6 +76,7 @@
 	
 	$va_available_cli_opts = array_merge(array(
 			"hostname|h-s" => 'Hostname of installation. If omitted default installation is used.',
+			"setup-s" => 'Specify the path to an alternate setup.php.',
 			"help" => "Displays available commands with descriptions."
 		), $va_command_opts);
 	
@@ -219,12 +220,18 @@
 	 * @return bool True if setup.php is located and loaded, false if setup.php could not be found.
 	 */
 	function _caUtilsLoadSetupPHP() {
-		
+		$vs_setup_path = 'setup.php';
+
 		// try to get hostname off of argv since we need that before anything else in a multi-database installation
+		// also detect the --setup flag, which accepts a path to an alternate setup.php
 		if (isset($_SERVER['argv']) && is_array($_SERVER['argv'])) {
 			foreach($_SERVER['argv'] as $vs_opt) {
 				if (preg_match("!^\-\-hostname\=([A-Za-z0-9_\-\.]+)!", $vs_opt, $va_matches) || preg_match("!^\-h\=([A-Za-z0-9_\-\.]+)!", $vs_opt, $va_matches)) {
 					$_SERVER['HTTP_HOST'] = $va_matches[1];
+					break;
+				}
+				if (preg_match('!^\-\-setup\=([A-Za-z0-9_\-\/\.]+)$!', $vs_opt, $va_matches)) {
+					$vs_setup_path = $va_matches[1];
 					break;
 				}
 			}
@@ -232,16 +239,17 @@
 		
 		// Look for environment variable
 		$vs_path = getenv("COLLECTIVEACCESS_HOME");
-		if (file_exists("{$vs_path}/setup.php")) {
-			require_once("{$vs_path}/setup.php");
+		if (file_exists("{$vs_path}/{$vs_setup_path}")) {
+			require_once("{$vs_path}/{$vs_setup_path}");
 			return true;
 		}
-		
+
 		// Look in current directory and then in parent directories
 		$vs_cwd = getcwd();
 		$va_cwd = explode("/", $vs_cwd);
 		while(sizeof($va_cwd) > 0) {
-			if (file_exists("/".join("/", $va_cwd)."/setup.php")) {
+			$vs_setup_path_fallback = "/".join("/", $va_cwd)."/".$vs_setup_path;
+			if (file_exists($vs_setup_path_fallback)) {
 				// Rewrite $_SERVER with paths that setup.php can use
 				//print_R($_SERVER);
 					// try to load pre-save paths
@@ -258,7 +266,7 @@
 					print "[\033[1;33mWARNING\033[0m] Guessing base path and hostname because configuration is not available. Loading any CollectiveAccess screen (except for the installer) in a web browser will cache configuration details and resolve this issue.\n\n";
 				}
 				
-				require_once("/".join("/", $va_cwd)."/setup.php");
+				require_once($vs_setup_path_fallback);
 				return true;
 			}
 			array_pop($va_cwd);


### PR DESCRIPTION
- Pass in a --setup=/path/to/setup.php option to caUtils
