### PR TITLE
Fixes for php 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: php
 
 php:
-  # Test against current PHP and previous version
+  # Test against current PHP and previous 2 versions
+  - 5.3
   - 5.4
   - 5.5
 

--- a/app/plugins/relationshipGenerator/relationshipGeneratorPlugin.php
+++ b/app/plugins/relationshipGenerator/relationshipGeneratorPlugin.php
@@ -80,11 +80,11 @@ class relationshipGeneratorPlugin extends BaseApplicationPlugin {
 
 	public function checkStatus() {
 		$va_errors = array();
-		$vo_this = $this;
+		$vo_config = $this->opo_config;
 		$this->_testConfigurationSection(
 			_t('top level'),
 			self::_getTopLevelConfigurationRequirements(),
-			function ($key) use ($vo_this) { return $vo_this->opo_config->get($key); },
+			function ($key) use ($vo_config) { return $vo_config->get($key); },
 			$va_errors
 		);
 		$va_rules = $this->opo_config->get('rules');

--- a/app/plugins/relationshipGenerator/relationshipGeneratorPlugin.php
+++ b/app/plugins/relationshipGenerator/relationshipGeneratorPlugin.php
@@ -80,10 +80,11 @@ class relationshipGeneratorPlugin extends BaseApplicationPlugin {
 
 	public function checkStatus() {
 		$va_errors = array();
+		$vo_this = $this;
 		$this->_testConfigurationSection(
 			_t('top level'),
 			self::_getTopLevelConfigurationRequirements(),
-			function ($key) { return $this->opo_config->get($key); },
+			function ($key) use ($vo_this) { return $vo_this->opo_config->get($key); },
 			$va_errors
 		);
 		$va_rules = $this->opo_config->get('rules');
@@ -282,7 +283,8 @@ class relationshipGeneratorPlugin extends BaseApplicationPlugin {
 						array( 'idno' => $pm_related_record ) :
 						array( 'id' => $pm_related_record ))
 		));
-		return sizeof($va_items) > 0 ? array_keys($va_items)[0] : null;
+		$va_keys = array_keys($va_items);
+		return sizeof($va_keys) > 0 ? $va_keys[0] : null;
 	}
 
 	/**

--- a/tests/plugins/AbstractPluginIntegrationTest.php
+++ b/tests/plugins/AbstractPluginIntegrationTest.php
@@ -164,10 +164,11 @@ abstract class AbstractPluginIntegrationTest extends PHPUnit_Framework_TestCase 
 
 			// Replace placeholders with generated (unique) values
 			while (strpos($vs_line, '%%') !== false) {
+				$vs_className = get_called_class();
 				$vs_line = preg_replace_callback(
 					'/%%(.*?)%%/',
-					function ($pa_match) {
-						return sizeof($pa_match) > 1 ? self::_getIdno($pa_match[1]) : '::: ERROR PARSING CONFIGURATION TEMPLATE :::';
+					function ($pa_match) use ($vs_className) {
+						return sizeof($pa_match) > 1 ? call_user_func(array( $vs_className, '_getIdno' ), $pa_match[1]) : '::: ERROR PARSING CONFIGURATION TEMPLATE :::';
 					},
 					$vs_line
 				);

--- a/tests/plugins/wamTitleGenerator/WamTitleGeneratorPluginIntegrationTest.php
+++ b/tests/plugins/wamTitleGenerator/WamTitleGeneratorPluginIntegrationTest.php
@@ -250,6 +250,7 @@ class WamTitleGeneratorPluginIntegrationTest extends AbstractPluginIntegrationTe
 	 */
 	private static function _getLabel($po_object, $ps_label_field) {
 		$vn_locale_id = ca_locales::getDefaultCataloguingLocaleID();
-		return $po_object->getPreferredLabels(array( $vn_locale_id ))[$po_object->getPrimaryKey()][$vn_locale_id][0][$ps_label_field];
+		$va_labels = $po_object->getPreferredLabels(array( $vn_locale_id ));
+		return $va_labels[$po_object->getPrimaryKey()][$vn_locale_id][0][$ps_label_field];
 	}
 }


### PR DESCRIPTION
- Add PHP 5.3 to target versions in Travis CI configuration.
- Make some code changes to plugin and unit tests, for PHP 5.3 compatibility.
