### PR TITLE
Prevent IE9 from entering Compatibility View.

### DIFF
--- a/themes/default/views/pageFormat/pageHeader.php
+++ b/themes/default/views/pageFormat/pageHeader.php
@@ -37,7 +37,8 @@
    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 	<head>
-	    <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
+		<meta http-equiv="X-UA-Compatible" content="IE=EDGE" />
+		<meta http-equiv="Content-type" content="text/html; charset=utf-8" />
 		<meta http-equiv="Content-Style-Type" content="text/css" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0"/>
 


### PR DESCRIPTION
- Add meta X-UA-Compatible element.
- http://stackoverflow.com/questions/6348959/how-to-disable-compatibility-view-in-ie
- http://stackoverflow.com/questions/12894082/how-to-prevent-ie9-from-rendering-intranet-sites-in-compatibility-mode

This has been tested using WAM machines and seems to be working correctly.
