### PR TITLE
Modifications for LDAP to be more configurable.

### DIFF
--- a/app/conf/authentication.conf
+++ b/app/conf/authentication.conf
@@ -18,6 +18,14 @@ ldap_port = 389
 ldap_base_dn = dc=mysite,dc=org
 ldap_user_ou = ou=Users
 ldap_group_cn = [CollectiveAccessUsers,CollectiveAccessAdmins]
+ldap_attribute_member_of = memberOf
+ldap_attribute_email = mail
+ldap_attribute_fname = givenName
+ldap_attribute_lname = sn
+
+ldap_bind_rdn_format = uid={username},{user_ou},{base_dn}
+ldap_user_search_dn_format = uid={username},{user_ou},{base_dn}
+ldap_user_search_filter_format = uid={username}
 
 # lists of roles/groups for newly created users
 


### PR DESCRIPTION
- Change the way LDAP groups are checked.  Previously it was searching for
  the group, then looking for the user logging in in the group record's
  "member" attribute.  Now it is searching for the user, then looking for
  the group in the user record's "memberOf" attribute (the actual name is
  configurable).
- Add configuration items for first name, last name and email attributes.
- Add configuration items for the format of the RDN used in the bind()
  operation, and the DN and filter used in the search() operation.  These
  configuration items can be built from other configuration items to
  reduce repetition in the configuration.
- Did some general code cleanup.
