### PR TITLE
Refactor `authenticateLDAP`

### DIFF
--- a/app/conf/authentication.conf
+++ b/app/conf/authentication.conf
@@ -10,35 +10,58 @@
 # Note that this feature requires the "ldap" PHP module which is not checked
 # in the standard CollectiveAccess configuration checks.
 
+# Set this to 1 to use LDAP authentication.
 use_ldap = 0
 
+# List of usernames who are authenticated locally, i.e. as though `use_ldap` is 0.
+ldap_local_users = []
+
+# LDAP protocol version, the default value should normally be used.
 ldap_protocol_version = 3
+
+# LDAP server location information.
+# For more details see http://php.net/manual/en/function.ldap-connect.php
 ldap_host = ldap.mysite.org
 ldap_port = 389
 
-ldap_group_cn = []
+# LDAP attribute names.
 ldap_attribute_member_of = memberOf
 ldap_attribute_email = mail
 ldap_attribute_fname = givenName
 ldap_attribute_lname = sn
 
-ldap_bind_rdn_format = uid={username},ou=Users,dc=mysite,dc=org
-ldap_user_search_dn_format = uid={username},ou=Users,dc=mysite,dc=org
-ldap_user_search_filter_format = uid={username}
+# RDN to use for the `ldap_bind()` operation; may contain "{username}" which is replaced by the username logging in.
+# For more details see http://php.net/manual/en/function.ldap-bind.php
+ldap_bind_rdn = uid={username},ou=Users,dc=mysite,dc=org
 
-# lists of roles/groups for newly created users
+# DN to use for the `ldap_search()` operation used to find the details / attributes of the user logging in; may contain
+# "{username}" which is replaced by the username logging in.
+# For more details see http://php.net/manual/en/function.ldap-search.php
+ldap_user_search_dn = uid={username},ou=Users,dc=mysite,dc=org
 
+# Filter to use for the `ldap_search()` operation used to find the details / attributes of the user logging in; may
+# contain "{username}" which is replaced by the username logging in.
+# For more details see http://php.net/manual/en/function.ldap-search.php
+ldap_user_search_filter = uid={username}
+
+# Lists of CollectiveAccess role names and group names for newly created users; these are applied only once when the
+# user is first authenticated via LDAP and does not exist locally in CollectiveAccess.
 ldap_users_default_roles = []
 ldap_users_default_groups = []
 
-# map of CA group name to LDAP DN (or multiple LDAP DNs as an array); if enabled, a user's LDAP group membership will
-# be checked upon each login and the user added to / removed from groups in CollectiveAccess.
+# CollectiveAccess can match on either a flat list of LDAP group DNs that the user must belong to in order to gain
+# access; or on a hash / map containing mappings from a CollectiveAccess group name to LDAP group DN (or multiple LDAP
+# group DNs as an array), where the user will gain access to the CollectiveAccess groups corresponding to the LDAP
+# groups that they belong to.
+ldap_group_match_type = list
+ldap_group_cn = []
 
-ldap_group_map_enabled = 0
-ldap_group_map = {}
+# Whether to update groups on every login (when set to 1) or only on first login (when set to 0, the default). This
+# only applies to the groups listed in `ldap_group_cn`, and only when `ldap_group_match_type` is "map"; it does not
+# apply to the roles or groups listed in `ldap_users_default_roles` and `ldap_users_default_groups`.
+ldap_group_update_on_every_login = 0
 
-# automatically activate new users? (otherwise they can't log in)
-
+# Automatically activate new users? (otherwise they can't log in)
 ldap_users_auto_active = 1
 
 

--- a/app/conf/authentication.conf
+++ b/app/conf/authentication.conf
@@ -12,25 +12,30 @@
 
 use_ldap = 0
 
+ldap_protocol_version = 3
 ldap_host = ldap.mysite.org
 ldap_port = 389
 
-ldap_base_dn = dc=mysite,dc=org
-ldap_user_ou = ou=Users
-ldap_group_cn = [CollectiveAccessUsers,CollectiveAccessAdmins]
+ldap_group_cn = []
 ldap_attribute_member_of = memberOf
 ldap_attribute_email = mail
 ldap_attribute_fname = givenName
 ldap_attribute_lname = sn
 
-ldap_bind_rdn_format = uid={username},{user_ou},{base_dn}
-ldap_user_search_dn_format = uid={username},{user_ou},{base_dn}
+ldap_bind_rdn_format = uid={username},ou=Users,dc=mysite,dc=org
+ldap_user_search_dn_format = uid={username},ou=Users,dc=mysite,dc=org
 ldap_user_search_filter_format = uid={username}
 
 # lists of roles/groups for newly created users
 
-ldap_users_default_roles = [cataloguer]
-ldap_users_default_groups = [cataloguer]
+ldap_users_default_roles = []
+ldap_users_default_groups = []
+
+# map of CA group name to LDAP DN (or multiple LDAP DNs as an array); if enabled, a user's LDAP group membership will
+# be checked upon each login and the user added to / removed from groups in CollectiveAccess.
+
+ldap_group_map_enabled = 0
+ldap_group_map = {}
 
 # automatically activate new users? (otherwise they can't log in)
 

--- a/app/conf/authentication.conf
+++ b/app/conf/authentication.conf
@@ -26,6 +26,7 @@ ldap_port = 389
 
 # LDAP attribute names.
 ldap_attribute_member_of = memberOf
+ldap_attribute_membership = memberuid
 ldap_attribute_email = mail
 ldap_attribute_fname = givenName
 ldap_attribute_lname = sn
@@ -54,12 +55,27 @@ ldap_users_default_groups = []
 # group DNs as an array), where the user will gain access to the CollectiveAccess groups corresponding to the LDAP
 # groups that they belong to.
 ldap_group_match_type = list
-ldap_group_cn = []
+ldap_group_dn = []
 
-# Whether to update groups on every login (when set to 1) or only on first login (when set to 0, the default). This
-# only applies to the groups listed in `ldap_group_cn`, and only when `ldap_group_match_type` is "map"; it does not
-# apply to the roles or groups listed in `ldap_users_default_roles` and `ldap_users_default_groups`.
-ldap_group_update_on_every_login = 0
+# Alternatively, in "list" mode, supply a list of CNs for groups, which are converted into search filters using the
+# given pattern.
+ldap_group_cn = []
+ldap_group_filter_pattern = (cn={group_cn})
+
+# Group matching can be done in one of two ways: group-to-user or user-to-group.  The former loads a group by DN and
+# looks for the user in its attributes (the attribute name is given by `ldap_attribute_membership`).  The latter takes
+# the user's attributes and looks for the group (the attribute name is given by `ldap_attribute_member_of`).
+ldap_group_match_method = group-to-user
+
+# DN to use for the `ldap_search()` operation used to find the details / attributes of a given group.  This is ignored
+# unless `ldap_group_match_method` is "group-to-user".
+# For more details see http://php.net/manual/en/function.ldap-search.php
+ldap_group_search_dn = dc=mysite,dc=org
+
+# Whether to update groups and roles on every login (when set to 1) or only on first login (when set to 0, the
+# default).  Note this applies to `ldap_users_default_roles` and `ldap_users_default_groups` as well as the
+# groups determined from LDAP lookups.
+ldap_acl_update_on_every_login = 0
 
 # Automatically activate new users? (otherwise they can't log in)
 ldap_users_auto_active = 1

--- a/app/models/ca_users.php
+++ b/app/models/ca_users.php
@@ -2569,64 +2569,71 @@ class ca_users extends BaseModel {
 	 * @return bool
 	 */
 	private function authenticateLDAP($ps_username="",$ps_password=""){
-		if(!function_exists("ldap_connect")){
+		if (!function_exists("ldap_connect")){
 			die("PHP's LDAP module is required for LDAP authentication!");
 		}
 
-		$vs_ldaphost = $this->opo_auth_config->get("ldap_host");
-		$vs_ldapport = $this->opo_auth_config->get("ldap_port");
-		$vs_base_dn = $this->opo_auth_config->get("ldap_base_dn");
-		$va_group_cn = $this->opo_auth_config->getList("ldap_group_cn");
-		$vs_user_ou = $this->opo_auth_config->get("ldap_user_ou");
-		$vs_attribute_member_of = $this->opo_auth_config->get("ldap_attribute_member_of");
-		$vs_attribute_email = $this->opo_auth_config->get("ldap_attribute_email");
-		$vs_attribute_fname = $this->opo_auth_config->get("ldap_attribute_fname");
-		$vs_attribute_lname = $this->opo_auth_config->get("ldap_attribute_lname");
-		$vs_bind_rdn = $this->postProcessLDAPConfigValue("ldap_bind_rdn_format", $ps_username, $vs_user_ou, $vs_base_dn);
-		$vs_search_dn = $this->postProcessLDAPConfigValue("ldap_search_dn_format", $ps_username, $vs_user_ou, $vs_base_dn);
-		$vs_search_filter = $this->postProcessLDAPConfigValue("ldap_search_filter_format", $ps_username, $vs_user_ou, $vs_base_dn);
-
-		$vo_ldap = ldap_connect($vs_ldaphost, $vs_ldapport) or die("could not connect to LDAP server");
-		if (!$vo_ldap) {
-			return false;
-		}
-
-		ldap_set_option($vo_ldap, LDAP_OPT_PROTOCOL_VERSION, 3);
-		$vo_bind = @ldap_bind($vo_ldap, $vs_bind_rdn, $ps_password);
+		$r_ldap = ldap_connect($this->opo_auth_config->get("ldap_host"), $this->opo_auth_config->get("ldap_port"));
+		ldap_set_option($r_ldap, LDAP_OPT_PROTOCOL_VERSION, intval($this->opo_auth_config->get("ldap_protocol_version")));
+		$vo_bind = ldap_bind($r_ldap, $this->injectUsername("ldap_bind_rdn_format", $ps_username), $ps_password);
 		if (!$vo_bind) {
-			// wrong credentials
-			ldap_unbind($vo_ldap);
+			$vn_errno = ldap_errno($r_ldap);
+			if ($vn_errno === 0x5b || $vn_errno < 0) { // see http://php.net/manual/en/function.ldap-errno.php#20665
+				// the server is down
+				die(ldap_error($r_ldap));
+			}
+			// invalid credentials, so prevent login
+			ldap_unbind($r_ldap);
 			return false;
 		}
 
-		$vo_results = ldap_search($vo_ldap, $vs_search_dn, $vs_search_filter);
+		$vo_results = ldap_search($r_ldap, $this->injectUsername("ldap_search_dn_format", $ps_username), $this->injectUsername("ldap_search_filter_format", $ps_username));
 		if (!$vo_results) {
-			// search error
-			ldap_unbind($vo_ldap);
+			// search error, so prevent login
+			ldap_unbind($r_ldap);
 			return false;
 		}
 
-		$vo_entry = ldap_first_entry($vo_ldap, $vo_results);
+		$vo_entry = ldap_first_entry($r_ldap, $vo_results);
 		if (!$vo_entry) {
-			// no results returned
-			ldap_unbind($vo_ldap);
+			// no results returned, so prevent login
+			ldap_unbind($r_ldap);
 			return false;
 		}
 
-		$va_attrs = ldap_get_attributes($vo_ldap, $vo_entry);
-		if (sizeof(array_intersect($va_group_cn, $va_attrs[$vs_attribute_member_of])) === 0) {
-			// user is not in any relevant groups
-			ldap_unbind($vo_ldap);
-			return false;
+		$va_attrs = ldap_get_attributes($r_ldap, $vo_entry);
+		$va_groups = array();
+		if ($this->opo_auth_config->getBoolean("ldap_group_map_enabled")) {
+			// determine the CA groups that the user should belong to, based on the LDAP group CNs that the user belongs to
+			foreach ($this->opo_auth_config->getAssoc("ldap_group_map") as $vs_ca_group => $va_ldap_groups) {
+				if (!is_array($va_ldap_groups)) {
+					$va_ldap_groups = array( $va_ldap_groups );
+				}
+				if ($this->userHasGroupLDAP($va_ldap_groups, $va_attrs)) {
+					$va_groups[] = $vs_ca_group;
+				}
+			}
+			if (sizeof($va_groups) === 0) {
+				// user is not in any relevant groups, so prevent login
+				ldap_unbind($r_ldap);
+				return false;
+			}
+		} else {
+			// simple check against array of LDAP group CNs
+			if ($this->userHasGroupLDAP($this->opo_auth_config->getList("ldap_group_cn"), $va_attrs)) {
+				// user is not in any relevant groups, so prevent login
+				ldap_unbind($r_ldap);
+				return false;
+			}
 		}
 
 		if (!$this->load(array( "user_name" => $ps_username ))) {
-			// first user login, authentication via LDAP successful
+			// first user login, authentication via LDAP successful, create the user
 			$this->set("user_name",$ps_username);
 			$this->set("password",$ps_password);
-			$this->set("email",$va_attrs[$vs_attribute_email][0]);
-			$this->set("fname",$va_attrs[$vs_attribute_fname][0]);
-			$this->set("lname",$va_attrs[$vs_attribute_lname][0]);
+			$this->set("email",$va_attrs[$this->opo_auth_config->get("ldap_attribute_email")][0]);
+			$this->set("fname",$va_attrs[$this->opo_auth_config->get("ldap_attribute_fname")][0]);
+			$this->set("lname",$va_attrs[$this->opo_auth_config->get("ldap_attribute_lname")][0]);
 			$this->set("active",$this->opo_auth_config->get("ldap_users_auto_active"));
 
 			$vn_mode = $this->getMode();
@@ -2640,20 +2647,23 @@ class ca_users extends BaseModel {
 			$this->setMode($vn_mode);
 		}
 
-		ldap_unbind($vo_ldap);
+		// TODO Now we know the user exists, we can add and remove groups according to their LDAP groups and `ldap_group_map`
+
+		ldap_unbind($r_ldap);
 		return true;
 	}
 	# ----------------------------------------
-	private function postProcessLDAPConfigValue($key, $ps_username, $ps_user_ou, $ps_base_dn) {
-		$result = $this->opo_auth_config->get($key);
-		$result = str_replace('{username}', $ps_username, $result);
-		$result = str_replace('{user_ou}', $ps_user_ou, $result);
-		$result = str_replace('{base_dn}', $ps_base_dn, $result);
-		return $result;
+	private function injectUsername($ps_key, $ps_username) {
+		return str_replace('{username}', $ps_username, $this->opo_auth_config->get($ps_key));
+	}
+	# ----------------------------------------
+	private function userHasGroupLDAP($pa_group_cn, $pa_user_attrs) {
+		// TODO Restore the OpenLDAP-supported method of doing this (for upstream)
+		return sizeof(array_intersect($pa_group_cn, $pa_user_attrs[$this->opo_auth_config->get("ldap_attribute_member_of")])) === 0;
 	}
 	# ----------------------------------------
 	/**
-	 * Do authentification against an external database (creates user based on directory 
+	 * Do authentification against an external database (creates user based on directory
 	 * information and config preferences in authentication.conf)
 	 * @param string $ps_username username
 	 * @param string $ps_password password


### PR DESCRIPTION
- Add preliminary support for `ldap_group_map` configuration, which maps
  CA groups from LDAP groups, as an alternative to the existing `group_cn`
  config item, which is just a flat list of group names to look for in
  order to authenticate the user.
- Fix LDAP connection code by removing unreachable conditions and adding
  correct check for connection errors.
- Get rid of `ldap_base_dn` and `ldap_user_ou` config items, they were only
  used for substitution, which is now inlined.
- Remove unwanted config from base config file.
- Add TODOs for remaining work.
- This is completely untested at this stage.
- Make protocol version a config item (intended for future maintaining
  compatibility with current and next protocol versions).
