### PR TITLE
Only use array keys if it is an array

### DIFF
--- a/app/plugins/relationshipGenerator/relationshipGeneratorPlugin.php
+++ b/app/plugins/relationshipGenerator/relationshipGeneratorPlugin.php
@@ -283,7 +283,8 @@ class relationshipGeneratorPlugin extends BaseApplicationPlugin {
 						array( 'idno' => $pm_related_record ) :
 						array( 'id' => $pm_related_record ))
 		));
-		$va_keys = array_keys($va_items);
+
+		$va_keys = is_array($va_items) ? array_keys($va_items) : null;
 		return sizeof($va_keys) > 0 ? $va_keys[0] : null;
 	}
 


### PR DESCRIPTION
Was getting a warning about $va_items not being an array. I looked at $po_instance->getRelatedItems() and that can return null, so this covers that case.
