### PR TITLE
Different types for different ranks

### DIFF
--- a/app/lib/ca/BundlableLabelableBaseModelWithAttributes.php
+++ b/app/lib/ca/BundlableLabelableBaseModelWithAttributes.php
@@ -497,10 +497,13 @@ class BundlableLabelableBaseModelWithAttributes extends LabelableBaseModelWithAt
 		$vs_return_as_link_text =		caGetOption('returnAsLinkText', $pa_options, '');
 		$vs_return_as_link_target =		caGetOption('returnAsLinkTarget', $pa_options, '');
 		$va_return_as_link_attributes =	caGetOption('returnAsLinkAttributes', $pa_options, array(), array('castTo' => 'array'));
-		
+		$vs_return_as_link_class = 		caGetOption('returnAsLinkClass', $pa_options,'');
+
 		$vb_return_all_locales =		caGetOption('returnAllLocales', $pa_options, false, array('castTo' => 'bool'));
 		$vs_delimiter =					caGetOption('delimiter', $pa_options, '');
 		$va_restrict_to_rel_types =		caGetOption('restrictToRelationshipTypes', $pa_options, null);
+
+		$va_restrict_hierarchy_to_types = caGetOption('restrictHierarchyToTypes', $pa_options, null);
 		
 		$va_filters = 					caGetOption('filters', $pa_options, array(), array('castTo' => 'array'));
 		

--- a/app/lib/ca/BundlableLabelableBaseModelWithAttributes.php
+++ b/app/lib/ca/BundlableLabelableBaseModelWithAttributes.php
@@ -497,13 +497,10 @@ class BundlableLabelableBaseModelWithAttributes extends LabelableBaseModelWithAt
 		$vs_return_as_link_text =		caGetOption('returnAsLinkText', $pa_options, '');
 		$vs_return_as_link_target =		caGetOption('returnAsLinkTarget', $pa_options, '');
 		$va_return_as_link_attributes =	caGetOption('returnAsLinkAttributes', $pa_options, array(), array('castTo' => 'array'));
-		$vs_return_as_link_class = 		caGetOption('returnAsLinkClass', $pa_options,'');
-
+		
 		$vb_return_all_locales =		caGetOption('returnAllLocales', $pa_options, false, array('castTo' => 'bool'));
 		$vs_delimiter =					caGetOption('delimiter', $pa_options, '');
 		$va_restrict_to_rel_types =		caGetOption('restrictToRelationshipTypes', $pa_options, null);
-
-		$va_restrict_hierarchy_to_types = caGetOption('restrictHierarchyToTypes', $pa_options, null);
 		
 		$va_filters = 					caGetOption('filters', $pa_options, array(), array('castTo' => 'array'));
 		

--- a/install/profiles/xml/wamcmis.xml
+++ b/install/profiles/xml/wamcmis.xml
@@ -61,7 +61,7 @@
                           <labels>
                             <label locale="en_AU" preferred="1">
                               <name_singular>Class</name_singular>
-                              <name_plural>Class</name_plural>
+                              <name_plural>Classes</name_plural>
                             </label>
                           </labels>
                           <items>
@@ -117,34 +117,34 @@
                                                       <labels>
                                                         <label locale="en_AU" preferred="1">
                                                           <name_singular>Superfamily</name_singular>
-                                                          <name_plural>Superfamily</name_plural>
+                                                          <name_plural>Superfamilies</name_plural>
                                                         </label>
                                                       </labels>
                                                       <items>
                                                         <item idno="family" enabled="1" default="0">
                                                           <labels>
                                                             <label locale="en_AU" preferred="1">
-                                                              <name_singular>Family</name_singular>
-                                                              <name_plural>Families</name_plural>
+                                                            <name_singular>Family</name_singular>
+                                                            <name_plural>Families</name_plural>
                                                             </label>
                                                           </labels>
                                                           <items>
                                                             <item idno="subfamily" enabled="1" default="0">
-                                                              <labels>
-                                                                <label locale="en_AU" preferred="1">
-                                                                  <name_singular>Subfamily</name_singular>
-                                                                  <name_plural>Subfamilies</name_plural>
-                                                                </label>
-                                                              </labels>
-                                                              <items>
-                                                                <item idno="tribe" enabled="1" default="0">
-                                                                  <labels>
-                                                                    <label locale="en_AU" preferred="1">
-                                                                      <name_singular>Tribe</name_singular>
-                                                                      <name_plural>Tribe</name_plural>
-                                                                    </label>
-                                                                  </labels>
-                                                                  <items>
+                                                            <labels>
+                                                            <label locale="en_AU" preferred="1">
+                                                            <name_singular>Subfamily</name_singular>
+                                                            <name_plural>Subfamilies</name_plural>
+                                                            </label>
+                                                            </labels>
+                                                            <items>
+                                                            <item idno="tribe" enabled="1" default="0">
+                                                            <labels>
+                                                            <label locale="en_AU" preferred="1">
+                                                            <name_singular>Tribe</name_singular>
+                                                            <name_plural>Tribes</name_plural>
+                                                            </label>
+                                                            </labels>
+                                                            <items>
                                                                     <item idno="genus" enabled="1" default="0">
                                                                       <labels>
                                                                         <label locale="en_AU" preferred="1">
@@ -153,39 +153,37 @@
                                                                         </label>
                                                                       </labels>
                                                                       <items>
-                                                                        <item idno="subgenus" enabled="1" default="0">
-                                                                          <labels>
-                                                                            <label locale="en_AU" preferred="1">
-                                                                              <name_singular>Subgenus</name_singular>
-                                                                              <name_plural>Subgenera</name_plural>
-                                                                            </label>
-                                                                          </labels>
-                                                                          <items>
-                                                                            <item idno="species" enabled="1" default="0">
-                                                                              <labels>
-                                                                                <label locale="en_AU" preferred="1">
-                                                                                  <name_singular>Species</name_singular>
-                                                                                  <name_plural>Species</name_plural>
-                                                                                </label>
-                                                                              </labels>
-                                                                              <items>
-                                                                                <item idno="subspecies" enabled="1" default="0">
-                                                                                  <labels>
-                                                                                    <label locale="en_AU" preferred="1">
-                                                                                      <name_singular>Subspecies</name_singular>
-                                                                                      <name_plural>Subspecies</name_plural>
-                                                                                    </label>
-                                                                                  </labels>
-                                                                                </item>
-                                                                              </items>
-                                                                            </item>
-                                                                          </items>
-                                                                        </item>
-                                                                      </items>
-                                                                    </item>
-                                                                  </items>
-                                                                </item>
-                                                              </items>
+                                                            <item idno="subgenus" enabled="1" default="0">
+                                                            <labels>
+                                                            <label locale="en_AU" preferred="1">
+                                                            <name_singular>Subgenus</name_singular>
+                                                            <name_plural>Subgenera</name_plural>
+                                                            </label>
+                                                            </labels>
+                                                            <items>
+                                                            <item idno="species" enabled="1" default="0">
+                                                            <labels>
+                                                            <label locale="en_AU" preferred="1">
+                                                            <name_singular>Species</name_singular>
+                                                            <name_plural>Species</name_plural>
+                                                            </label>
+                                                            </labels>
+                                                            <items>
+                                                            <item idno="subspecies" enabled="1" default="0">
+                                                            <labels>
+                                                            <label locale="en_AU" preferred="1">
+                                                            <name_singular>Subspecies</name_singular>
+                                                            <name_plural>Subspecies</name_plural>
+                                                            </label>
+                                                            </labels>
+                                                            </item>
+                                                            </items>
+                                                            </item>
+                                                            </items>
+                                                            </item>
+                                                            </items>
+                                                            </item>
+                                                            </items>
                                                             </item>
                                                           </items>
                                                         </item>
@@ -199,23 +197,20 @@
                                         </item>
                                       </items>
                                     </item>
-
                                   </items>
                                 </item>
                               </items>
                             </item>
-
                           </items>
                         </item>
-
                       </items>
                     </item>
-
                   </items>
                 </item>
-
               </items>
             </item>
+          </items>
+        </item>
 
           </items>
         </item>
@@ -2069,7 +2064,7 @@
           <labels>
             <label locale="en_AU" preferred="1">
               <name_singular>n. sp.</name_singular>
-              <name_plural>n. spp.</name_plural>
+              <name_plural>n. sp.</name_plural>
             </label>
           </labels>
         </item>
@@ -2078,6 +2073,14 @@
             <label locale="en_AU" preferred="1">
               <name_singular>...</name_singular>
               <name_plural>...</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="spp_" enabled="1" default="0">
+          <labels>
+            <label locale="en_AU" preferred="1">
+              <name_singular>spp.</name_singular>
+              <name_plural>spp.</name_plural>
             </label>
           </labels>
         </item>
@@ -4102,35 +4105,11 @@
                 </label>
               </labels>
             </item>
-            <item idno="1" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>bone</name_singular>
-                  <name_plural>bone</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="2" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
                   <name_singular>bone artefact</name_singular>
                   <name_plural>bone artefact</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>point</name_singular>
-                  <name_plural>point</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="669" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>ceramic</name_singular>
-                  <name_plural>ceramic</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>earthenware, porcelain, stoneware, pot sherds</name_singular>
-                  <name_plural>earthenware, porcelain, stoneware, pot sherds</name_plural>
                 </label>
               </labels>
             </item>
@@ -4150,11 +4129,67 @@
                 </label>
               </labels>
             </item>
-            <item idno="17" enabled="1" default="0">
+            <item idno="6" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
-                  <name_singular>general</name_singular>
-                  <name_plural>general</name_plural>
+                  <name_singular>human remains</name_singular>
+                  <name_plural>human remains</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="669" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>ceramic</name_singular>
+                  <name_plural>ceramic</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="670" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>wooden artefact</name_singular>
+                  <name_plural>wooden artefact</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="682" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>pottery</name_singular>
+                  <name_plural>pottery</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="1" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>bone</name_singular>
+                  <name_plural>bone</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="2" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>bone artefact</name_singular>
+                  <name_plural>bone artefact</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="3" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>coral</name_singular>
+                  <name_plural>coral</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="4" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>faunal remains</name_singular>
+                  <name_plural>faunal remains</name_plural>
                 </label>
               </labels>
             </item>
@@ -4163,10 +4198,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>glass</name_singular>
                   <name_plural>glass</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>Kimberley point, bottle, shard</name_singular>
-                  <name_plural>Kimberley point, bottle, shard</name_plural>
                 </label>
               </labels>
             </item>
@@ -4212,25 +4243,9 @@
             </item>
             <item idno="11" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>Amphora, Roman pottery</name_singular>
-                  <name_plural>Amphora, Roman pottery</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>pot</name_singular>
                   <name_plural>pot</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="682" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>clay, pot, bowl, vase, plate, container</name_singular>
-                  <name_plural>clay, pot, bowl, vase, plate, container</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>pottery</name_singular>
-                  <name_plural>pottery</name_plural>
                 </label>
               </labels>
             </item>
@@ -4244,10 +4259,6 @@
             </item>
             <item idno="13" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>fish hook</name_singular>
-                  <name_plural>fish hook</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>shell artefact</name_singular>
                   <name_plural>shell artefact</name_plural>
@@ -4264,14 +4275,6 @@
             </item>
             <item idno="15" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>chips, waste</name_singular>
-                  <name_plural>chips, waste</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>flake</name_singular>
-                  <name_plural>flake</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>stone</name_singular>
                   <name_plural>stone</name_plural>
@@ -4280,21 +4283,17 @@
             </item>
             <item idno="16" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>axe, backed blade, core, fishhook file, flake, retouched flake, grindstone, hammerstone, point, scraper, tula</name_singular>
-                  <name_plural>axe, backed blade, core, fishhook file, flake, retouched flake, grindstone, hammerstone, point, scraper, tula</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>stone artefact</name_singular>
                   <name_plural>stone artefact</name_plural>
                 </label>
               </labels>
             </item>
-            <item idno="670" enabled="1" default="0">
+            <item idno="17" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
-                  <name_singular>wooden artefact</name_singular>
-                  <name_plural>wooden artefact</name_plural>
+                  <name_singular>general</name_singular>
+                  <name_plural>general</name_plural>
                 </label>
               </labels>
             </item>
@@ -4308,12 +4307,296 @@
             </label>
           </labels>
           <items>
+            <item idno="115" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>leg guard</name_singular>
+                  <name_plural>leg guard</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="116" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>leg band</name_singular>
+                  <name_plural>leg band</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="117" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>leggings (covers all of the calf)</name_singular>
+                  <name_plural>leggings (covers all of the calf)</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="118" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>lip ornament</name_singular>
+                  <name_plural>lip ornament</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="119" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>mouth ornament (held in the mouth)</name_singular>
+                  <name_plural>mouth ornament (held in the mouth)</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="120" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>neck ornament</name_singular>
+                  <name_plural>neck ornament</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="121" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>nose ornament</name_singular>
+                  <name_plural>nose ornament</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="122" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>ornament</name_singular>
+                  <name_plural>ornament</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="123" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>pendant</name_singular>
+                  <name_plural>pendant</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="124" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>prayer wheel</name_singular>
+                  <name_plural>prayer wheel</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="125" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>pubic cover</name_singular>
+                  <name_plural>pubic cover</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="126" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>purse</name_singular>
+                  <name_plural>purse</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="127" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>shorts</name_singular>
+                  <name_plural>shorts</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="128" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>sash (around body)</name_singular>
+                  <name_plural>sash (around body)</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="129" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>scarf (neck/head)</name_singular>
+                  <name_plural>scarf (neck/head)</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="130" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>shirt</name_singular>
+                  <name_plural>shirt</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="131" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>shell ring</name_singular>
+                  <name_plural>shell ring</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="132" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>shoulder ornament</name_singular>
+                  <name_plural>shoulder ornament</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="133" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>skirt (goes all way around waist)</name_singular>
+                  <name_plural>skirt (goes all way around waist)</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="134" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>sock</name_singular>
+                  <name_plural>sock</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="135" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>spectacles</name_singular>
+                  <name_plural>spectacles</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="136" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>staff</name_singular>
+                  <name_plural>staff</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="137" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>tassel</name_singular>
+                  <name_plural>tassel</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="138" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>thumbguard</name_singular>
+                  <name_plural>thumbguard</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="139" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>trousers</name_singular>
+                  <name_plural>trousers</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="140" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>umbrella</name_singular>
+                  <name_plural>umbrella</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="141" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>waistband</name_singular>
+                  <name_plural>waistband</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="142" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>wallet</name_singular>
+                  <name_plural>wallet</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="143" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>wig</name_singular>
+                  <name_plural>wig</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="622" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>beads</name_singular>
+                  <name_plural>beads</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="640" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>walking stick</name_singular>
+                  <name_plural>walking stick</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="643" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>armour</name_singular>
+                  <name_plural>armour</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="648" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>dance chain</name_singular>
+                  <name_plural>dance chain</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="654" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>suit</name_singular>
+                  <name_plural>suit</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="658" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>mosquito whisk</name_singular>
+                  <name_plural>mosquito whisk</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="69" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>footwear</name_singular>
+                  <name_plural>footwear</name_plural>
+                </label>
+              </labels>
+            </item>
             <item idno="70" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>ankle band, anklet</name_singular>
-                  <name_plural>ankle band, anklet</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>ankle ornament</name_singular>
                   <name_plural>ankle ornament</name_plural>
@@ -4334,14 +4617,6 @@
                   <name_singular>arm guard</name_singular>
                   <name_plural>arm guard</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>armour</name_singular>
-                  <name_plural>armour</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>wristguard</name_singular>
-                  <name_plural>wristguard</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="73" enabled="1" default="0">
@@ -4350,17 +4625,13 @@
                   <name_singular>arm ornament</name_singular>
                   <name_plural>arm ornament</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>armlet, armband, arm ring, bangle, wristband</name_singular>
-                  <name_plural>armlet, armband, arm ring, bangle, wristband</name_plural>
-                </label>
               </labels>
             </item>
-            <item idno="643" enabled="1" default="0">
+            <item idno="74" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
-                  <name_singular>armour</name_singular>
-                  <name_plural>armour</name_plural>
+                  <name_singular>backflap</name_singular>
+                  <name_plural>backflap</name_plural>
                 </label>
               </labels>
             </item>
@@ -4369,14 +4640,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>back ornament</name_singular>
                   <name_plural>back ornament</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="74" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>backflap</name_singular>
-                  <name_plural>backflap</name_plural>
                 </label>
               </labels>
             </item>
@@ -4393,22 +4656,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>bead (single beads)</name_singular>
                   <name_plural>bead (single beads)</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>currency, ceremonial</name_singular>
-                  <name_plural>currency, ceremonial</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="622" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>beads</name_singular>
-                  <name_plural>beads</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>trade beads</name_singular>
-                  <name_plural>trade beads</name_plural>
                 </label>
               </labels>
             </item>
@@ -4450,10 +4697,6 @@
                   <name_singular>breast ornament (hangs on the chest)</name_singular>
                   <name_plural>breast ornament (hangs on the chest)</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>gorget</name_singular>
-                  <name_plural>gorget</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="83" enabled="1" default="0">
@@ -4486,14 +4729,6 @@
                   <name_singular>cap (fits the skull)</name_singular>
                   <name_plural>cap (fits the skull)</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>kopi widow's cap</name_singular>
-                  <name_plural>kopi widow's cap</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>mourning cap</name_singular>
-                  <name_plural>mourning cap</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="87" enabled="1" default="0">
@@ -4501,14 +4736,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>cape</name_singular>
                   <name_plural>cape</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>cloak</name_singular>
-                  <name_plural>cloak</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>rain cape</name_singular>
-                  <name_plural>rain cape</name_plural>
                 </label>
               </labels>
             </item>
@@ -4525,14 +4752,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>coat</name_singular>
                   <name_plural>coat</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>jacket</name_singular>
-                  <name_plural>jacket</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>rain coat</name_singular>
-                  <name_plural>rain coat</name_plural>
                 </label>
               </labels>
             </item>
@@ -4554,10 +4773,6 @@
             </item>
             <item idno="92" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>armour</name_singular>
-                  <name_plural>armour</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>cuirass</name_singular>
                   <name_plural>cuirass</name_plural>
@@ -4572,39 +4787,19 @@
                 </label>
               </labels>
             </item>
-            <item idno="648" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>dance chain</name_singular>
-                  <name_plural>dance chain</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="94" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
                   <name_singular>dance stick</name_singular>
                   <name_plural>dance stick</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>dance wand</name_singular>
-                  <name_plural>dance wand</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="95" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>ceremonial</name_singular>
-                  <name_plural>ceremonial</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>dress</name_singular>
                   <name_plural>dress</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>wedding</name_singular>
-                  <name_plural>wedding</name_plural>
                 </label>
               </labels>
             </item>
@@ -4614,10 +4809,6 @@
                   <name_singular>ear ornament</name_singular>
                   <name_plural>ear ornament</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>ear plug, ear ring, ear stick</name_singular>
-                  <name_plural>ear plug, ear ring, ear stick</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="97" enabled="1" default="0">
@@ -4625,14 +4816,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>eyeshade</name_singular>
                   <name_plural>eyeshade</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>snow goggles</name_singular>
-                  <name_plural>snow goggles</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>sunshade</name_singular>
-                  <name_plural>sunshade</name_plural>
                 </label>
               </labels>
             </item>
@@ -4662,17 +4845,9 @@
             </item>
             <item idno="101" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>currency</name_singular>
-                  <name_plural>currency</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>feather tuft</name_singular>
                   <name_plural>feather tuft</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>plume</name_singular>
-                  <name_plural>plume</name_plural>
                 </label>
               </labels>
             </item>
@@ -4684,24 +4859,8 @@
                 </label>
               </labels>
             </item>
-            <item idno="69" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>footwear</name_singular>
-                  <name_plural>footwear</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>footwear, boot, shoe, sandal</name_singular>
-                  <name_plural>footwear, boot, shoe, sandal</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="104" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>forehead band</name_singular>
-                  <name_plural>forehead band</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>forehead ornament (hanging on forehead)</name_singular>
                   <name_plural>forehead ornament (hanging on forehead)</name_plural>
@@ -4710,10 +4869,6 @@
             </item>
             <item idno="105" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>armour</name_singular>
-                  <name_plural>armour</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>gauntlet</name_singular>
                   <name_plural>gauntlet</name_plural>
@@ -4725,10 +4880,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>girdle (sits on hips)</name_singular>
                   <name_plural>girdle (sits on hips)</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>string girdle</name_singular>
-                  <name_plural>string girdle</name_plural>
                 </label>
               </labels>
             </item>
@@ -4746,25 +4897,13 @@
                   <name_singular>hair ornament</name_singular>
                   <name_plural>hair ornament</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>hair pin</name_singular>
-                  <name_plural>hair pin</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="109" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>baseball cap</name_singular>
-                  <name_plural>baseball cap</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>hat (crown &amp; brim)</name_singular>
                   <name_plural>hat (crown &amp; brim)</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>hood</name_singular>
-                  <name_plural>hood</name_plural>
                 </label>
               </labels>
             </item>
@@ -4782,22 +4921,10 @@
                   <name_singular>head dress</name_singular>
                   <name_plural>head dress</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>head ornament</name_singular>
-                  <name_plural>head ornament</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>mourning</name_singular>
-                  <name_plural>mourning</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="112" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>armour</name_singular>
-                  <name_plural>armour</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>helmet</name_singular>
                   <name_plural>helmet</name_plural>
@@ -4806,341 +4933,9 @@
             </item>
             <item idno="113" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>fi-etwork</name_singular>
-                  <name_plural>fi-etwork</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>kap kap</name_singular>
                   <name_plural>kap kap</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="114" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>armour</name_singular>
-                  <name_plural>armour</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>knuckle duster</name_singular>
-                  <name_plural>knuckle duster</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="116" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>leg band</name_singular>
-                  <name_plural>leg band</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="115" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>armour</name_singular>
-                  <name_plural>armour</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>leg guard</name_singular>
-                  <name_plural>leg guard</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="117" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>leggings (covers all of the calf)</name_singular>
-                  <name_plural>leggings (covers all of the calf)</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="118" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>lip ornament</name_singular>
-                  <name_plural>lip ornament</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="658" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>mosquito whisk</name_singular>
-                  <name_plural>mosquito whisk</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="119" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>mouth ornament (held in the mouth)</name_singular>
-                  <name_plural>mouth ornament (held in the mouth)</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="120" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>charm, currency, yoke</name_singular>
-                  <name_plural>charm, currency, yoke</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>neck ornament</name_singular>
-                  <name_plural>neck ornament</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>necklace, pendant, collar, necklet, neck band</name_singular>
-                  <name_plural>necklace, pendant, collar, necklet, neck band</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="121" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>nose ornament</name_singular>
-                  <name_plural>nose ornament</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>nose pin nose plug, nose ring</name_singular>
-                  <name_plural>nose pin nose plug, nose ring</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="122" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>ornament</name_singular>
-                  <name_plural>ornament</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="123" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>pendant</name_singular>
-                  <name_plural>pendant</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="124" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>prayer wheel</name_singular>
-                  <name_plural>prayer wheel</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="125" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>(female) pubic apron, apron, genital cover (male) phallocrypt, penis gourd, loin cloth</name_singular>
-                  <name_plural>(female) pubic apron, apron, genital cover (male) phallocrypt, penis gourd, loin cloth</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>pubic cover</name_singular>
-                  <name_plural>pubic cover</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="126" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>finger ring</name_singular>
-                  <name_plural>finger ring</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>purse</name_singular>
-                  <name_plural>purse</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>ring, shell ring</name_singular>
-                  <name_plural>ring, shell ring</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="128" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>sash (around body)</name_singular>
-                  <name_plural>sash (around body)</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="129" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>scarf (neck/head)</name_singular>
-                  <name_plural>scarf (neck/head)</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="131" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>currency</name_singular>
-                  <name_plural>currency</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>shell ring</name_singular>
-                  <name_plural>shell ring</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="130" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>blouse, t-shirt, jumper</name_singular>
-                  <name_plural>blouse, t-shirt, jumper</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>shirt</name_singular>
-                  <name_plural>shirt</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="127" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>boardshorts</name_singular>
-                  <name_plural>boardshorts</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>shorts</name_singular>
-                  <name_plural>shorts</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="132" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>shoulder ornament</name_singular>
-                  <name_plural>shoulder ornament</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="133" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>skirt (goes all way around waist)</name_singular>
-                  <name_plural>skirt (goes all way around waist)</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>tubular</name_singular>
-                  <name_plural>tubular</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="134" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>sock</name_singular>
-                  <name_plural>sock</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="135" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>spectacles</name_singular>
-                  <name_plural>spectacles</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="136" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>staff</name_singular>
-                  <name_plural>staff</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>walking stick</name_singular>
-                  <name_plural>walking stick</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="654" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>suit</name_singular>
-                  <name_plural>suit</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="137" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>tassel</name_singular>
-                  <name_plural>tassel</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="138" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>thumbguard</name_singular>
-                  <name_plural>thumbguard</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="139" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>jeans,</name_singular>
-                  <name_plural>jeans,</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>pants</name_singular>
-                  <name_plural>pants</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>trousers</name_singular>
-                  <name_plural>trousers</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="140" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>umbrella</name_singular>
-                  <name_plural>umbrella</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="141" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>belt</name_singular>
-                  <name_plural>belt</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>waistband</name_singular>
-                  <name_plural>waistband</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="640" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>walking stick</name_singular>
-                  <name_plural>walking stick</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="142" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>wallet</name_singular>
-                  <name_plural>wallet</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="143" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>wig</name_singular>
-                  <name_plural>wig</name_plural>
                 </label>
               </labels>
             </item>
@@ -5154,6 +4949,22 @@
             </label>
           </labels>
           <items>
+            <item idno="646" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>tile</name_singular>
+                  <name_plural>tile</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="650" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>nail</name_singular>
+                  <name_plural>nail</name_plural>
+                </label>
+              </labels>
+            </item>
             <item idno="18" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
@@ -5234,35 +5045,11 @@
                 </label>
               </labels>
             </item>
-            <item idno="650" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>nail</name_singular>
-                  <name_plural>nail</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="28" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
                   <name_singular>plaque</name_singular>
                   <name_plural>plaque</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="30" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>ceremonial</name_singular>
-                  <name_plural>ceremonial</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>pole</name_singular>
-                  <name_plural>pole</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>ridge pole</name_singular>
-                  <name_plural>ridge pole</name_plural>
                 </label>
               </labels>
             </item>
@@ -5274,12 +5061,16 @@
                 </label>
               </labels>
             </item>
+            <item idno="30" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>pole</name_singular>
+                  <name_plural>pole</name_plural>
+                </label>
+              </labels>
+            </item>
             <item idno="31" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>roof tile</name_singular>
-                  <name_plural>roof tile</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>roofing</name_singular>
                   <name_plural>roofing</name_plural>
@@ -5310,14 +5101,6 @@
                 </label>
               </labels>
             </item>
-            <item idno="646" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>tile</name_singular>
-                  <name_plural>tile</name_plural>
-                </label>
-              </labels>
-            </item>
           </items>
         </item>
         <item idno="ARE" enabled="1" default="0">
@@ -5328,6 +5111,30 @@
             </label>
           </labels>
           <items>
+            <item idno="600" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>set</name_singular>
+                  <name_plural>set</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="626" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>general</name_singular>
+                  <name_plural>general</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="676" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>pencil sharpener</name_singular>
+                  <name_plural>pencil sharpener</name_plural>
+                </label>
+              </labels>
+            </item>
             <item idno="45" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
@@ -5341,14 +5148,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>case</name_singular>
                   <name_plural>case</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="626" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>general</name_singular>
-                  <name_plural>general</name_plural>
                 </label>
               </labels>
             </item>
@@ -5384,35 +5183,11 @@
                 </label>
               </labels>
             </item>
-            <item idno="676" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>pencil sharpener</name_singular>
-                  <name_plural>pencil sharpener</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="51" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>paint pot, paint container</name_singular>
-                  <name_plural>paint pot, paint container</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>pigment container</name_singular>
                   <name_plural>pigment container</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="600" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>brush, paint, paint pots</name_singular>
-                  <name_plural>brush, paint, paint pots</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>set</name_singular>
-                  <name_plural>set</name_plural>
                 </label>
               </labels>
             </item>
@@ -5426,31 +5201,43 @@
             </label>
           </labels>
           <items>
-            <item idno="37" enabled="1" default="0">
+            <item idno="599" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
-                  <name_singular>animal figure</name_singular>
-                  <name_plural>animal figure</name_plural>
+                  <name_singular>ceramic</name_singular>
+                  <name_plural>ceramic</name_plural>
                 </label>
               </labels>
             </item>
-            <item idno="36" enabled="1" default="0">
+            <item idno="629" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
-                  <name_singular>anthropomorphic figure</name_singular>
-                  <name_plural>anthropomorphic figure</name_plural>
+                  <name_singular>glass</name_singular>
+                  <name_plural>glass</name_plural>
                 </label>
               </labels>
             </item>
-            <item idno="38" enabled="1" default="0">
+            <item idno="661" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
-                  <name_singular>board</name_singular>
-                  <name_plural>board</name_plural>
+                  <name_singular>wire art</name_singular>
+                  <name_plural>wire art</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>carved bark, carved tablet, wooden tablet, ancestral tablet</name_singular>
-                  <name_plural>carved bark, carved tablet, wooden tablet, ancestral tablet</name_plural>
+              </labels>
+            </item>
+            <item idno="662" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>tin sculpture</name_singular>
+                  <name_plural>tin sculpture</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="664" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>wood sculpture</name_singular>
+                  <name_plural>wood sculpture</name_plural>
                 </label>
               </labels>
             </item>
@@ -5459,10 +5246,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>Bone</name_singular>
                   <name_plural>Bone</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>Bone Sculpture</name_singular>
-                  <name_plural>Bone Sculpture</name_plural>
                 </label>
               </labels>
             </item>
@@ -5474,47 +5257,43 @@
                 </label>
               </labels>
             </item>
-            <item idno="599" enabled="1" default="0">
+            <item idno="35" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
-                  <name_singular>ceramic</name_singular>
-                  <name_plural>ceramic</name_plural>
+                  <name_singular>painting</name_singular>
+                  <name_plural>painting</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>pottery</name_singular>
-                  <name_plural>pottery</name_plural>
+              </labels>
+            </item>
+            <item idno="36" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>anthropomorphic figure</name_singular>
+                  <name_plural>anthropomorphic figure</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="37" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>animal figure</name_singular>
+                  <name_plural>animal figure</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="38" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>board</name_singular>
+                  <name_plural>board</name_plural>
                 </label>
               </labels>
             </item>
             <item idno="39" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>boab nut, baobab nut, worked stone, boabab nut, turtle shell, decorated egg, charm, brideprice, carved face</name_singular>
-                  <name_plural>boab nut, baobab nut, worked stone, boabab nut, turtle shell, decorated egg, charm, brideprice, carved face</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>decorated object</name_singular>
                   <name_plural>decorated object</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="41" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>drawing</name_singular>
-                  <name_plural>drawing</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="629" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>art glass</name_singular>
-                  <name_plural>art glass</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>glass</name_singular>
-                  <name_plural>glass</name_plural>
                 </label>
               </labels>
             </item>
@@ -5523,6 +5302,14 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>head</name_singular>
                   <name_plural>head</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="41" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>drawing</name_singular>
+                  <name_plural>drawing</name_plural>
                 </label>
               </labels>
             </item>
@@ -5536,73 +5323,17 @@
             </item>
             <item idno="43" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>bark, paper, photograph</name_singular>
-                  <name_plural>bark, paper, photograph</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>mixed media</name_singular>
                   <name_plural>mixed media</name_plural>
                 </label>
               </labels>
             </item>
-            <item idno="35" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>bark, pen &amp; ink, ink wash, palm spathe, children's, ground, acrylic</name_singular>
-                  <name_plural>bark, pen &amp; ink, ink wash, palm spathe, children's, ground, acrylic</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>painting</name_singular>
-                  <name_plural>painting</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="44" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>hand, impression, stencil</name_singular>
-                  <name_plural>hand, impression, stencil</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>rock art</name_singular>
                   <name_plural>rock art</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="662" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>recycled materials</name_singular>
-                  <name_plural>recycled materials</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>tin sculpture</name_singular>
-                  <name_plural>tin sculpture</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="661" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>tourist, souvenir</name_singular>
-                  <name_plural>tourist, souvenir</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>wire art</name_singular>
-                  <name_plural>wire art</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="664" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>chain</name_singular>
-                  <name_plural>chain</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>wood sculpture</name_singular>
-                  <name_plural>wood sculpture</name_plural>
                 </label>
               </labels>
             </item>
@@ -5624,23 +5355,19 @@
                 </label>
               </labels>
             </item>
-            <item idno="54" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>depilatory</name_singular>
-                  <name_plural>depilatory</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>hair remover</name_singular>
-                  <name_plural>hair remover</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="53" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
                   <name_singular>hairbrush</name_singular>
                   <name_plural>hairbrush</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="54" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>hair remover</name_singular>
+                  <name_plural>hair remover</name_plural>
                 </label>
               </labels>
             </item>
@@ -5668,23 +5395,19 @@
                 </label>
               </labels>
             </item>
-            <item idno="62" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>adze, bowl, implement, hammer, needle</name_singular>
-                  <name_plural>adze, bowl, implement, hammer, needle</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>tattoo equipment</name_singular>
-                  <name_plural>tattoo equipment</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="58" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
                   <name_singular>tooth blackener</name_singular>
                   <name_plural>tooth blackener</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="60" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>toothbrush</name_singular>
+                  <name_plural>toothbrush</name_plural>
                 </label>
               </labels>
             </item>
@@ -5696,11 +5419,11 @@
                 </label>
               </labels>
             </item>
-            <item idno="60" enabled="1" default="0">
+            <item idno="62" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
-                  <name_singular>toothbrush</name_singular>
-                  <name_plural>toothbrush</name_plural>
+                  <name_singular>tattoo equipment</name_singular>
+                  <name_plural>tattoo equipment</name_plural>
                 </label>
               </labels>
             </item>
@@ -5804,20 +5527,8 @@
                 </label>
               </labels>
             </item>
-            <item idno="151" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>manuscript</name_singular>
-                  <name_plural>manuscript</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="149" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>leaf tanget</name_singular>
-                  <name_plural>leaf tanget</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>message</name_singular>
                   <name_plural>message</name_plural>
@@ -5830,9 +5541,13 @@
                   <name_singular>message stick</name_singular>
                   <name_plural>message stick</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>toa</name_singular>
-                  <name_plural>toa</name_plural>
+              </labels>
+            </item>
+            <item idno="151" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>manuscript</name_singular>
+                  <name_plural>manuscript</name_plural>
                 </label>
               </labels>
             </item>
@@ -5860,10 +5575,6 @@
                   <name_singular>bag</name_singular>
                   <name_plural>bag</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>dilly bag, billum</name_singular>
-                  <name_plural>dilly bag, billum</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="154" enabled="1" default="0">
@@ -5879,10 +5590,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>betelnut container</name_singular>
                   <name_plural>betelnut container</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>stimulant &amp; accessories</name_singular>
-                  <name_plural>stimulant &amp; accessories</name_plural>
                 </label>
               </labels>
             </item>
@@ -5900,10 +5607,6 @@
                   <name_singular>bowl</name_singular>
                   <name_plural>bowl</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>dish</name_singular>
-                  <name_plural>dish</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="158" enabled="1" default="0">
@@ -5911,10 +5614,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>box</name_singular>
                   <name_plural>box</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>carton</name_singular>
-                  <name_plural>carton</name_plural>
                 </label>
               </labels>
             </item>
@@ -5932,9 +5631,13 @@
                   <name_singular>can</name_singular>
                   <name_plural>can</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>tin</name_singular>
-                  <name_plural>tin</name_plural>
+              </labels>
+            </item>
+            <item idno="161" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>cup</name_singular>
+                  <name_plural>cup</name_plural>
                 </label>
               </labels>
             </item>
@@ -5946,14 +5649,6 @@
                 </label>
               </labels>
             </item>
-            <item idno="161" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>cup</name_singular>
-                  <name_plural>cup</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="163" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
@@ -5962,19 +5657,19 @@
                 </label>
               </labels>
             </item>
-            <item idno="165" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>gourd</name_singular>
-                  <name_plural>gourd</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="164" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
                   <name_singular>horn</name_singular>
                   <name_plural>horn</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="165" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>gourd</name_singular>
+                  <name_plural>gourd</name_plural>
                 </label>
               </labels>
             </item>
@@ -6004,17 +5699,9 @@
             </item>
             <item idno="169" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>chinam box</name_singular>
-                  <name_plural>chinam box</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>lime container</name_singular>
                   <name_plural>lime container</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>stimulant &amp; accessories</name_singular>
-                  <name_plural>stimulant &amp; accessories</name_plural>
                 </label>
               </labels>
             </item>
@@ -6028,34 +5715,14 @@
             </item>
             <item idno="171" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>- enter in ART EQUIPMENT</name_singular>
-                  <name_plural>- enter in ART EQUIPMENT</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>paint container</name_singular>
                   <name_plural>paint container</name_plural>
                 </label>
               </labels>
             </item>
-            <item idno="668" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>ochre</name_singular>
-                  <name_plural>ochre</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>paperbark wallet</name_singular>
-                  <name_plural>paperbark wallet</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="172" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>- enter in ART EQUIPMENT</name_singular>
-                  <name_plural>- enter in ART EQUIPMENT</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>pigment container</name_singular>
                   <name_plural>pigment container</name_plural>
@@ -6068,18 +5735,10 @@
                   <name_singular>plate</name_singular>
                   <name_plural>plate</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>platter</name_singular>
-                  <name_plural>platter</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="174" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>Jug, Wine container</name_singular>
-                  <name_plural>Jug, Wine container</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>pot</name_singular>
                   <name_plural>pot</name_plural>
@@ -6088,10 +5747,6 @@
             </item>
             <item idno="175" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>pot ring, headpad, pot stand, calabash rim</name_singular>
-                  <name_plural>pot ring, headpad, pot stand, calabash rim</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>pot support</name_singular>
                   <name_plural>pot support</name_plural>
@@ -6108,10 +5763,6 @@
             </item>
             <item idno="177" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>- enter in PASTIME</name_singular>
-                  <name_plural>- enter in PASTIME</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>snuff box</name_singular>
                   <name_plural>snuff box</name_plural>
@@ -6158,6 +5809,14 @@
                 </label>
               </labels>
             </item>
+            <item idno="668" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>paperbark wallet</name_singular>
+                  <name_plural>paperbark wallet</name_plural>
+                </label>
+              </labels>
+            </item>
           </items>
         </item>
         <item idno="CUR" enabled="1" default="0">
@@ -6184,35 +5843,11 @@
                 </label>
               </labels>
             </item>
-            <item idno="647" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>gold weight</name_singular>
-                  <name_plural>gold weight</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>money, gold</name_singular>
-                  <name_plural>money, gold</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="185" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
                   <name_singular>kula valuable</name_singular>
                   <name_plural>kula valuable</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="660" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>gold weight, shell money, note, coin</name_singular>
-                  <name_plural>gold weight, shell money, note, coin</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>money</name_singular>
-                  <name_plural>money</name_plural>
                 </label>
               </labels>
             </item>
@@ -6232,15 +5867,27 @@
                 </label>
               </labels>
             </item>
+            <item idno="647" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>gold weight</name_singular>
+                  <name_plural>gold weight</name_plural>
+                </label>
+              </labels>
+            </item>
             <item idno="656" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>money, teeth</name_singular>
-                  <name_plural>money, teeth</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>tooth money</name_singular>
                   <name_plural>tooth money</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="660" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>money</name_singular>
+                  <name_plural>money</name_plural>
                 </label>
               </labels>
             </item>
@@ -6254,26 +5901,6 @@
             </label>
           </labels>
           <items>
-            <item idno="667" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>book</name_singular>
-                  <name_plural>book</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="665" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>advertising, exhibition</name_singular>
-                  <name_plural>advertising, exhibition</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>brochure</name_singular>
-                  <name_plural>brochure</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="609" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
@@ -6304,10 +5931,6 @@
                   <name_singular>diaries</name_singular>
                   <name_plural>diaries</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>note book</name_singular>
-                  <name_plural>note book</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="613" enabled="1" default="0">
@@ -6323,14 +5946,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>identification</name_singular>
                   <name_plural>identification</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="679" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>information pack</name_singular>
-                  <name_plural>information pack</name_plural>
                 </label>
               </labels>
             </item>
@@ -6355,18 +5970,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>letters</name_singular>
                   <name_plural>letters</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="685" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>Magazine</name_singular>
-                  <name_plural>Magazine</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>Magazine</name_singular>
-                  <name_plural>Magazine</name_plural>
                 </label>
               </labels>
             </item>
@@ -6402,27 +6005,43 @@
                 </label>
               </labels>
             </item>
+            <item idno="637" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>tablet</name_singular>
+                  <name_plural>tablet</name_plural>
+                </label>
+              </labels>
+            </item>
             <item idno="638" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>heiroglyphs</name_singular>
-                  <name_plural>heiroglyphs</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>papyrus</name_singular>
                   <name_plural>papyrus</name_plural>
                 </label>
               </labels>
             </item>
-            <item idno="637" enabled="1" default="0">
+            <item idno="665" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>cuneiform, tablet, slate</name_singular>
-                  <name_plural>cuneiform, tablet, slate</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
-                  <name_singular>tablet</name_singular>
-                  <name_plural>tablet</name_plural>
+                  <name_singular>brochure</name_singular>
+                  <name_plural>brochure</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="667" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>book</name_singular>
+                  <name_plural>book</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="679" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>information pack</name_singular>
+                  <name_plural>information pack</name_plural>
                 </label>
               </labels>
             </item>
@@ -6431,6 +6050,14 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>ticket</name_singular>
                   <name_plural>ticket</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="685" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>Magazine</name_singular>
+                  <name_plural>Magazine</name_plural>
                 </label>
               </labels>
             </item>
@@ -6482,10 +6109,6 @@
                   <name_singular>betelnut crusher</name_singular>
                   <name_plural>betelnut crusher</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>stimulant &amp; accessories</name_singular>
-                  <name_plural>stimulant &amp; accessories</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="192" enabled="1" default="0">
@@ -6512,14 +6135,6 @@
                 </label>
               </labels>
             </item>
-            <item idno="196" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>candle holder</name_singular>
-                  <name_plural>candle holder</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="195" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
@@ -6528,15 +6143,11 @@
                 </label>
               </labels>
             </item>
-            <item idno="59" enabled="1" default="0">
+            <item idno="196" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
-                  <name_singular>coconut opener</name_singular>
-                  <name_plural>coconut opener</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food preparation</name_singular>
-                  <name_plural>food preparation</name_plural>
+                  <name_singular>candle holder</name_singular>
+                  <name_plural>candle holder</name_plural>
                 </label>
               </labels>
             </item>
@@ -6545,14 +6156,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>cooking stone</name_singular>
                   <name_plural>cooking stone</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food preparation</name_singular>
-                  <name_plural>food preparation</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>oven stone</name_singular>
-                  <name_plural>oven stone</name_plural>
                 </label>
               </labels>
             </item>
@@ -6574,10 +6177,6 @@
             </item>
             <item idno="200" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>drill, fire plough, poker, fire, stick, flint, lighter</name_singular>
-                  <name_plural>drill, fire plough, poker, fire, stick, flint, lighter</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>fire tool</name_singular>
                   <name_plural>fire tool</name_plural>
@@ -6590,29 +6189,13 @@
                   <name_singular>food cover</name_singular>
                   <name_plural>food cover</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food preparation</name_singular>
-                  <name_plural>food preparation</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="202" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food preparation</name_singular>
-                  <name_plural>food preparation</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>fork</name_singular>
                   <name_plural>fork</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="653" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>general</name_singular>
-                  <name_plural>general</name_plural>
                 </label>
               </labels>
             </item>
@@ -6626,10 +6209,6 @@
             </item>
             <item idno="204" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food preparation</name_singular>
-                  <name_plural>food preparation</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>grindstone</name_singular>
                   <name_plural>grindstone</name_plural>
@@ -6646,10 +6225,6 @@
             </item>
             <item idno="206" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food preparation</name_singular>
-                  <name_plural>food preparation</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>hook</name_singular>
                   <name_plural>hook</name_plural>
@@ -6658,10 +6233,6 @@
             </item>
             <item idno="207" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food preparation</name_singular>
-                  <name_plural>food preparation</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>implement</name_singular>
                   <name_plural>implement</name_plural>
@@ -6670,10 +6241,6 @@
             </item>
             <item idno="208" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>ceremonial</name_singular>
-                  <name_plural>ceremonial</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>incense burner</name_singular>
                   <name_plural>incense burner</name_plural>
@@ -6690,10 +6257,6 @@
             </item>
             <item idno="210" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food preparation</name_singular>
-                  <name_plural>food preparation</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>ladle</name_singular>
                   <name_plural>ladle</name_plural>
@@ -6702,10 +6265,6 @@
             </item>
             <item idno="211" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>lamp, torch</name_singular>
-                  <name_plural>lamp, torch</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>light</name_singular>
                   <name_plural>light</name_plural>
@@ -6722,13 +6281,17 @@
             </item>
             <item idno="213" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food preparation, stimulant &amp; accessories</name_singular>
-                  <name_plural>food preparation, stimulant &amp; accessories</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>mortar</name_singular>
                   <name_plural>mortar</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="214" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>other</name_singular>
+                  <name_plural>other</name_plural>
                 </label>
               </labels>
             </item>
@@ -6750,49 +6313,25 @@
             </item>
             <item idno="217" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food preparation</name_singular>
-                  <name_plural>food preparation</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>nutcracker</name_singular>
                   <name_plural>nutcracker</name_plural>
                 </label>
               </labels>
             </item>
-            <item idno="214" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>camp debris</name_singular>
-                  <name_plural>camp debris</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>other</name_singular>
-                  <name_plural>other</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="235" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food preparation, cooking, frying</name_singular>
-                  <name_plural>food preparation, cooking, frying</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>pan</name_singular>
-                  <name_plural>pan</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="218" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food preparation, stimulant &amp; accessories</name_singular>
-                  <name_plural>food preparation, stimulant &amp; accessories</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>pestle</name_singular>
                   <name_plural>pestle</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="219" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>stool</name_singular>
+                  <name_plural>stool</name_plural>
                 </label>
               </labels>
             </item>
@@ -6806,10 +6345,6 @@
             </item>
             <item idno="221" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food preparation</name_singular>
-                  <name_plural>food preparation</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>pounder</name_singular>
                   <name_plural>pounder</name_plural>
@@ -6826,10 +6361,6 @@
             </item>
             <item idno="223" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food preparation</name_singular>
-                  <name_plural>food preparation</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>rice winnower</name_singular>
                   <name_plural>rice winnower</name_plural>
@@ -6838,10 +6369,6 @@
             </item>
             <item idno="224" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food preparation</name_singular>
-                  <name_plural>food preparation</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>sago adze</name_singular>
                   <name_plural>sago adze</name_plural>
@@ -6850,14 +6377,6 @@
             </item>
             <item idno="225" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food preparation</name_singular>
-                  <name_plural>food preparation</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>pudding knife</name_singular>
-                  <name_plural>pudding knife</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>sago knife</name_singular>
                   <name_plural>sago knife</name_plural>
@@ -6866,10 +6385,6 @@
             </item>
             <item idno="226" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food preparation</name_singular>
-                  <name_plural>food preparation</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>sago peg</name_singular>
                   <name_plural>sago peg</name_plural>
@@ -6878,10 +6393,6 @@
             </item>
             <item idno="227" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food preparation</name_singular>
-                  <name_plural>food preparation</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>sago pounder</name_singular>
                   <name_plural>sago pounder</name_plural>
@@ -6890,25 +6401,9 @@
             </item>
             <item idno="228" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food preparation</name_singular>
-                  <name_plural>food preparation</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>sago trough</name_singular>
                   <name_plural>sago trough</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="231" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>chair, stool</name_singular>
-                  <name_plural>chair, stool</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>scat</name_singular>
-                  <name_plural>scat</name_plural>
                 </label>
               </labels>
             </item>
@@ -6922,22 +6417,22 @@
             </item>
             <item idno="230" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food preparation</name_singular>
-                  <name_plural>food preparation</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>seed cleaner</name_singular>
                   <name_plural>seed cleaner</name_plural>
                 </label>
               </labels>
             </item>
+            <item idno="231" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>scat</name_singular>
+                  <name_plural>scat</name_plural>
+                </label>
+              </labels>
+            </item>
             <item idno="232" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food preparation</name_singular>
-                  <name_plural>food preparation</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>skewer</name_singular>
                   <name_plural>skewer</name_plural>
@@ -6954,26 +6449,22 @@
             </item>
             <item idno="234" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food preparation, stimulant &amp; accessories</name_singular>
-                  <name_plural>food preparation, stimulant &amp; accessories</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>lime spatula</name_singular>
-                  <name_plural>lime spatula</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>spatula</name_singular>
                   <name_plural>spatula</name_plural>
                 </label>
               </labels>
             </item>
+            <item idno="235" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>pan</name_singular>
+                  <name_plural>pan</name_plural>
+                </label>
+              </labels>
+            </item>
             <item idno="236" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food preparation</name_singular>
-                  <name_plural>food preparation</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>spoon</name_singular>
                   <name_plural>spoon</name_plural>
@@ -6982,10 +6473,6 @@
             </item>
             <item idno="237" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>base</name_singular>
-                  <name_plural>base</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>stand</name_singular>
                   <name_plural>stand</name_plural>
@@ -6994,30 +6481,14 @@
             </item>
             <item idno="238" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food preparation</name_singular>
-                  <name_plural>food preparation</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>stirrer</name_singular>
                   <name_plural>stirrer</name_plural>
                 </label>
               </labels>
             </item>
-            <item idno="219" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>stool</name_singular>
-                  <name_plural>stool</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="239" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food preparation</name_singular>
-                  <name_plural>food preparation</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>strainer</name_singular>
                   <name_plural>strainer</name_plural>
@@ -7029,14 +6500,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>table</name_singular>
                   <name_plural>table</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="678" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>tea towel</name_singular>
-                  <name_plural>tea towel</name_plural>
                 </label>
               </labels>
             </item>
@@ -7056,6 +6519,30 @@
                 </label>
               </labels>
             </item>
+            <item idno="653" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>general</name_singular>
+                  <name_plural>general</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="678" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>tea towel</name_singular>
+                  <name_plural>tea towel</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="59" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>coconut opener</name_singular>
+                  <name_plural>coconut opener</name_plural>
+                </label>
+              </labels>
+            </item>
           </items>
         </item>
         <item idno="HFW" enabled="1" default="0">
@@ -7066,35 +6553,11 @@
             </label>
           </labels>
           <items>
-            <item idno="251" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>?</name_singular>
-                  <name_plural>?</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="243" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
                   <name_singular>arrow</name_singular>
                   <name_plural>arrow</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="598" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>axe</name_singular>
-                  <name_plural>axe</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>kodj</name_singular>
-                  <name_plural>kodj</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>tool</name_singular>
-                  <name_plural>tool</name_plural>
                 </label>
               </labels>
             </item>
@@ -7144,18 +6607,6 @@
                   <name_singular>bow</name_singular>
                   <name_plural>bow</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>bowstave</name_singular>
-                  <name_plural>bowstave</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="257" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>bow &amp; arrow</name_singular>
-                  <name_plural>bow &amp; arrow</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="250" enabled="1" default="0">
@@ -7163,6 +6614,14 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>bullet</name_singular>
                   <name_plural>bullet</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="251" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>?</name_singular>
+                  <name_plural>?</name_plural>
                 </label>
               </labels>
             </item>
@@ -7180,10 +6639,6 @@
                   <name_singular>dagger</name_singular>
                   <name_plural>dagger</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>hilt (part)</name_singular>
-                  <name_plural>hilt (part)</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="254" enabled="1" default="0">
@@ -7200,10 +6655,6 @@
                   <name_singular>dart case</name_singular>
                   <name_plural>dart case</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>dart pouch</name_singular>
-                  <name_plural>dart pouch</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="256" enabled="1" default="0">
@@ -7212,13 +6663,13 @@
                   <name_singular>decoy</name_singular>
                   <name_plural>decoy</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>fish, emu, octopus</name_singular>
-                  <name_plural>fish, emu, octopus</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>lure</name_singular>
-                  <name_plural>lure</name_plural>
+              </labels>
+            </item>
+            <item idno="257" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>bow &amp; arrow</name_singular>
+                  <name_plural>bow &amp; arrow</name_plural>
                 </label>
               </labels>
             </item>
@@ -7227,38 +6678,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>fighting pick</name_singular>
                   <name_plural>fighting pick</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="264" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>fish hook</name_singular>
-                  <name_plural>fish hook</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="262" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>fish hook container</name_singular>
-                  <name_plural>fish hook container</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="263" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>fish hook making tool</name_singular>
-                  <name_plural>fish hook making tool</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="261" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>fish kite</name_singular>
-                  <name_plural>fish kite</name_plural>
                 </label>
               </labels>
             </item>
@@ -7278,27 +6697,43 @@
                 </label>
               </labels>
             </item>
-            <item idno="267" enabled="1" default="0">
+            <item idno="261" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
-                  <name_singular>fishing box</name_singular>
-                  <name_plural>fishing box</name_plural>
+                  <name_singular>fish kite</name_singular>
+                  <name_plural>fish kite</name_plural>
                 </label>
               </labels>
             </item>
-            <item idno="649" enabled="1" default="0">
+            <item idno="262" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
-                  <name_singular>fishing flare</name_singular>
-                  <name_plural>fishing flare</name_plural>
+                  <name_singular>fish hook container</name_singular>
+                  <name_plural>fish hook container</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>light</name_singular>
-                  <name_plural>light</name_plural>
+              </labels>
+            </item>
+            <item idno="263" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>fish hook making tool</name_singular>
+                  <name_plural>fish hook making tool</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>torch</name_singular>
-                  <name_plural>torch</name_plural>
+              </labels>
+            </item>
+            <item idno="264" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>fish hook</name_singular>
+                  <name_plural>fish hook</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="265" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>fishing line</name_singular>
+                  <name_plural>fishing line</name_plural>
                 </label>
               </labels>
             </item>
@@ -7310,15 +6745,11 @@
                 </label>
               </labels>
             </item>
-            <item idno="265" enabled="1" default="0">
+            <item idno="267" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>fishing hooks, fishing kit, fish hook</name_singular>
-                  <name_plural>fishing hooks, fishing kit, fish hook</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
-                  <name_singular>fishing line</name_singular>
-                  <name_plural>fishing line</name_plural>
+                  <name_singular>fishing box</name_singular>
+                  <name_plural>fishing box</name_plural>
                 </label>
               </labels>
             </item>
@@ -7400,10 +6831,6 @@
                   <name_singular>lure</name_singular>
                   <name_plural>lure</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>octopus, fish</name_singular>
-                  <name_plural>octopus, fish</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="278" enabled="1" default="0">
@@ -7424,10 +6851,6 @@
             </item>
             <item idno="280" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>kangaroo, pig, bird, crocodile, fish, fowl</name_singular>
-                  <name_plural>kangaroo, pig, bird, crocodile, fish, fowl</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>net</name_singular>
                   <name_plural>net</name_plural>
@@ -7455,18 +6878,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>quiver</name_singular>
                   <name_plural>quiver</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="663" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>sabre</name_singular>
-                  <name_plural>sabre</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>sword</name_singular>
-                  <name_plural>sword</name_plural>
                 </label>
               </labels>
             </item>
@@ -7512,10 +6923,6 @@
             </item>
             <item idno="289" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>club, parrying</name_singular>
-                  <name_plural>club, parrying</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>shield</name_singular>
                   <name_plural>shield</name_plural>
@@ -7548,10 +6955,6 @@
             </item>
             <item idno="293" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>head, point, fishing, barbed, dugong, goose</name_singular>
-                  <name_plural>head, point, fishing, barbed, dugong, goose</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>spear</name_singular>
                   <name_plural>spear</name_plural>
@@ -7568,14 +6971,6 @@
             </item>
             <item idno="295" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>cutlass</name_singular>
-                  <name_plural>cutlass</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>lacerator</name_singular>
-                  <name_plural>lacerator</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>sword</name_singular>
                   <name_plural>sword</name_plural>
@@ -7592,10 +6987,6 @@
             </item>
             <item idno="297" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>rat, possum, wallaby, fish, eel, bird</name_singular>
-                  <name_plural>rat, possum, wallaby, fish, eel, bird</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>trap</name_singular>
                   <name_plural>trap</name_plural>
@@ -7615,6 +7006,30 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>trident</name_singular>
                   <name_plural>trident</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="598" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>axe</name_singular>
+                  <name_plural>axe</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="649" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>fishing flare</name_singular>
+                  <name_plural>fishing flare</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="663" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>sabre</name_singular>
+                  <name_plural>sabre</name_plural>
                 </label>
               </labels>
             </item>
@@ -7665,10 +7080,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>hoof cover</name_singular>
                   <name_plural>hoof cover</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>rag knot</name_singular>
-                  <name_plural>rag knot</name_plural>
                 </label>
               </labels>
             </item>
@@ -7722,14 +7133,6 @@
                 </label>
               </labels>
             </item>
-            <item idno="672" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>calipers</name_singular>
-                  <name_plural>calipers</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="310" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
@@ -7743,14 +7146,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>compass</name_singular>
                   <name_plural>compass</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="673" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>ruler</name_singular>
-                  <name_plural>ruler</name_plural>
                 </label>
               </labels>
             </item>
@@ -7778,6 +7173,22 @@
                 </label>
               </labels>
             </item>
+            <item idno="672" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>calipers</name_singular>
+                  <name_plural>calipers</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="673" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>ruler</name_singular>
+                  <name_plural>ruler</name_plural>
+                </label>
+              </labels>
+            </item>
           </items>
         </item>
         <item idno="MUL" enabled="1" default="0">
@@ -7788,26 +7199,6 @@
             </label>
           </labels>
           <items>
-            <item idno="675" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>3D glasses</name_singular>
-                  <name_plural>3D glasses</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="683" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>Camera</name_singular>
-                  <name_plural>Camera</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>Camera, Video Recorder, Olympus, Nikkon, Sony, Lense</name_singular>
-                  <name_plural>Camera, Video Recorder, Olympus, Nikkon, Sony, Lense</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="315" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
@@ -7824,23 +7215,19 @@
                 </label>
               </labels>
             </item>
-            <item idno="318" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>historic, archival</name_singular>
-                  <name_plural>historic, archival</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>photograph</name_singular>
-                  <name_plural>photograph</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="317" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
                   <name_singular>postcard</name_singular>
                   <name_plural>postcard</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="318" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>photograph</name_singular>
+                  <name_plural>photograph</name_plural>
                 </label>
               </labels>
             </item>
@@ -7884,6 +7271,22 @@
                 </label>
               </labels>
             </item>
+            <item idno="675" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>3D glasses</name_singular>
+                  <name_plural>3D glasses</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="683" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>Camera</name_singular>
+                  <name_plural>Camera</name_plural>
+                </label>
+              </labels>
+            </item>
           </items>
         </item>
         <item idno="MUS" enabled="1" default="0">
@@ -7912,10 +7315,6 @@
             </item>
             <item idno="326" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>didgeridoo</name_singular>
-                  <name_plural>didgeridoo</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>drone pipe</name_singular>
                   <name_plural>drone pipe</name_plural>
@@ -7927,10 +7326,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>drum</name_singular>
                   <name_plural>drum</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>kundu drum, drum ring, drum skin, drum stick, hand drum, slit drum, water drum, friction drum, nose flute</name_singular>
-                  <name_plural>kundu drum, drum ring, drum skin, drum stick, hand drum, slit drum, water drum, friction drum, nose flute</name_plural>
                 </label>
               </labels>
             </item>
@@ -7968,10 +7363,6 @@
             </item>
             <item idno="332" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>conch, shell trumpet, vuvuzela</name_singular>
-                  <name_plural>conch, shell trumpet, vuvuzela</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>horn</name_singular>
                   <name_plural>horn</name_plural>
@@ -7980,10 +7371,6 @@
             </item>
             <item idno="333" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>devil's scarer</name_singular>
-                  <name_plural>devil's scarer</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>instrument</name_singular>
                   <name_plural>instrument</name_plural>
@@ -7995,10 +7382,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>jaw harp</name_singular>
                   <name_plural>jaw harp</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>jew's harp, jaws harp</name_singular>
-                  <name_plural>jew's harp, jaws harp</name_plural>
                 </label>
               </labels>
             </item>
@@ -8024,9 +7407,13 @@
                   <name_singular>musical pipes</name_singular>
                   <name_plural>musical pipes</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>pan flute, pandean pipes</name_singular>
-                  <name_plural>pan flute, pandean pipes</name_plural>
+              </labels>
+            </item>
+            <item idno="338" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>percussion stick</name_singular>
+                  <name_plural>percussion stick</name_plural>
                 </label>
               </labels>
             </item>
@@ -8038,20 +7425,8 @@
                 </label>
               </labels>
             </item>
-            <item idno="338" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>percussion stick</name_singular>
-                  <name_plural>percussion stick</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="340" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>ceremonial</name_singular>
-                  <name_plural>ceremonial</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>prayer bell</name_singular>
                   <name_plural>prayer bell</name_plural>
@@ -8068,10 +7443,6 @@
             </item>
             <item idno="342" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>castanet</name_singular>
-                  <name_plural>castanet</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>rattle</name_singular>
                   <name_plural>rattle</name_plural>
@@ -8080,10 +7451,6 @@
             </item>
             <item idno="343" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>beater</name_singular>
-                  <name_plural>beater</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>striker</name_singular>
                   <name_plural>striker</name_plural>
@@ -8140,27 +7507,11 @@
             </label>
           </labels>
           <items>
-            <item idno="645" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>betelnut mortar</name_singular>
-                  <name_plural>betelnut mortar</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>stimulant &amp; accessories</name_singular>
-                  <name_plural>stimulant &amp; accessories</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="349" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
                   <name_singular>cigar</name_singular>
                   <name_plural>cigar</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>stimulant &amp; accessories</name_singular>
-                  <name_plural>stimulant &amp; accessories</name_plural>
                 </label>
               </labels>
             </item>
@@ -8170,10 +7521,6 @@
                   <name_singular>cigarette holder</name_singular>
                   <name_plural>cigarette holder</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>stimulant &amp; accessories</name_singular>
-                  <name_plural>stimulant &amp; accessories</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="351" enabled="1" default="0">
@@ -8181,10 +7528,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>kava</name_singular>
                   <name_plural>kava</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>stimulant &amp; accessories</name_singular>
-                  <name_plural>stimulant &amp; accessories</name_plural>
                 </label>
               </labels>
             </item>
@@ -8194,10 +7537,6 @@
                   <name_singular>lime spatula</name_singular>
                   <name_plural>lime spatula</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>stimulant &amp; accessories</name_singular>
-                  <name_plural>stimulant &amp; accessories</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="353" enabled="1" default="0">
@@ -8205,10 +7544,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>lime stick</name_singular>
                   <name_plural>lime stick</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>stimulant &amp; accessories</name_singular>
-                  <name_plural>stimulant &amp; accessories</name_plural>
                 </label>
               </labels>
             </item>
@@ -8218,30 +7553,10 @@
                   <name_singular>opium</name_singular>
                   <name_plural>opium</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>stimulant &amp; accessories</name_singular>
-                  <name_plural>stimulant &amp; accessories</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="657" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>opium scales</name_singular>
-                  <name_plural>opium scales</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>stimulant &amp; accessories</name_singular>
-                  <name_plural>stimulant &amp; accessories</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="355" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>opium, tobacco, stimulant &amp; accessories</name_singular>
-                  <name_plural>opium, tobacco, stimulant &amp; accessories</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>pipe</name_singular>
                   <name_plural>pipe</name_plural>
@@ -8254,10 +7569,6 @@
                   <name_singular>pipe case</name_singular>
                   <name_plural>pipe case</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>stimulant &amp; accessories</name_singular>
-                  <name_plural>stimulant &amp; accessories</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="357" enabled="1" default="0">
@@ -8265,10 +7576,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>pituri</name_singular>
                   <name_plural>pituri</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>stimulant &amp; accessories</name_singular>
-                  <name_plural>stimulant &amp; accessories</name_plural>
                 </label>
               </labels>
             </item>
@@ -8278,10 +7585,6 @@
                   <name_singular>snuff box</name_singular>
                   <name_plural>snuff box</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>stimulant &amp; accessories</name_singular>
-                  <name_plural>stimulant &amp; accessories</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="359" enabled="1" default="0">
@@ -8290,18 +7593,10 @@
                   <name_singular>snuff spoon</name_singular>
                   <name_plural>snuff spoon</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>stimulant &amp; accessories</name_singular>
-                  <name_plural>stimulant &amp; accessories</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="360" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>stimulant &amp; accessories</name_singular>
-                  <name_plural>stimulant &amp; accessories</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>tobacco</name_singular>
                   <name_plural>tobacco</name_plural>
@@ -8310,13 +7605,25 @@
             </item>
             <item idno="361" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>stimulant &amp; accessories</name_singular>
-                  <name_plural>stimulant &amp; accessories</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>tobacco pouch</name_singular>
                   <name_plural>tobacco pouch</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="645" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>betelnut mortar</name_singular>
+                  <name_plural>betelnut mortar</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="657" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>opium scales</name_singular>
+                  <name_plural>opium scales</name_plural>
                 </label>
               </labels>
             </item>
@@ -8354,10 +7661,6 @@
                   <name_singular>animal</name_singular>
                   <name_plural>animal</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food, palolo worm, stingray tail</name_singular>
-                  <name_plural>food, palolo worm, stingray tail</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="364" enabled="1" default="0">
@@ -8381,10 +7684,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>bird body</name_singular>
                   <name_plural>bird body</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>bird breast</name_singular>
-                  <name_plural>bird breast</name_plural>
                 </label>
               </labels>
             </item>
@@ -8412,14 +7711,6 @@
                 </label>
               </labels>
             </item>
-            <item idno="372" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>cobweb</name_singular>
-                  <name_plural>cobweb</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="370" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
@@ -8436,15 +7727,19 @@
                 </label>
               </labels>
             </item>
+            <item idno="372" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>cobweb</name_singular>
+                  <name_plural>cobweb</name_plural>
+                </label>
+              </labels>
+            </item>
             <item idno="373" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
                   <name_singular>edible clay</name_singular>
                   <name_plural>edible clay</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food</name_singular>
-                  <name_plural>food</name_plural>
                 </label>
               </labels>
             </item>
@@ -8453,10 +7748,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>edible earth</name_singular>
                   <name_plural>edible earth</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food</name_singular>
-                  <name_plural>food</name_plural>
                 </label>
               </labels>
             </item>
@@ -8482,38 +7773,18 @@
                   <name_singular>fluid</name_singular>
                   <name_plural>fluid</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food</name_singular>
-                  <name_plural>food</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="378" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food</name_singular>
-                  <name_plural>food</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>fruit</name_singular>
                   <name_plural>fruit</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>pith berry</name_singular>
-                  <name_plural>pith berry</name_plural>
                 </label>
               </labels>
             </item>
             <item idno="379" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>'Aboriginal bread'</name_singular>
-                  <name_plural>'Aboriginal bread'</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food</name_singular>
-                  <name_plural>food</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>fungi</name_singular>
                   <name_plural>fungi</name_plural>
@@ -8546,10 +7817,6 @@
             </item>
             <item idno="383" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food</name_singular>
-                  <name_plural>food</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>insects</name_singular>
                   <name_plural>insects</name_plural>
@@ -8562,10 +7829,6 @@
                   <name_singular>kava leaf</name_singular>
                   <name_plural>kava leaf</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>stimulant &amp; accessories</name_singular>
-                  <name_plural>stimulant &amp; accessories</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="385" enabled="1" default="0">
@@ -8574,10 +7837,6 @@
                   <name_singular>kava root</name_singular>
                   <name_plural>kava root</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>stimulant &amp; accessories</name_singular>
-                  <name_plural>stimulant &amp; accessories</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="386" enabled="1" default="0">
@@ -8585,10 +7844,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>leaf</name_singular>
                   <name_plural>leaf</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>stimulant &amp; accessories</name_singular>
-                  <name_plural>stimulant &amp; accessories</name_plural>
                 </label>
               </labels>
             </item>
@@ -8602,25 +7857,9 @@
             </item>
             <item idno="388" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food, candlenut - enter in DOMICILE]</name_singular>
-                  <name_plural>food, candlenut - enter in DOMICILE]</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>nut</name_singular>
                   <name_plural>nut</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="625" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>ochre</name_singular>
-                  <name_plural>ochre</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>paint</name_singular>
-                  <name_plural>paint</name_plural>
                 </label>
               </labels>
             </item>
@@ -8629,6 +7868,14 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>oil</name_singular>
                   <name_plural>oil</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="390" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>plant</name_singular>
+                  <name_plural>plant</name_plural>
                 </label>
               </labels>
             </item>
@@ -8646,34 +7893,10 @@
                   <name_singular>pigment</name_singular>
                   <name_plural>pigment</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>stone, chalk, ochre, lime, cinnabar, manganese oxide</name_singular>
-                  <name_plural>stone, chalk, ochre, lime, cinnabar, manganese oxide</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="390" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food</name_singular>
-                  <name_plural>food</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>moss</name_singular>
-                  <name_plural>moss</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>plant</name_singular>
-                  <name_plural>plant</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="394" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food</name_singular>
-                  <name_plural>food</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>pod</name_singular>
                   <name_plural>pod</name_plural>
@@ -8686,18 +7909,10 @@
                   <name_singular>resin/gum</name_singular>
                   <name_plural>resin/gum</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>rosin, lacquer</name_singular>
-                  <name_plural>rosin, lacquer</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="396" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food, stimulant &amp; accessories</name_singular>
-                  <name_plural>food, stimulant &amp; accessories</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>root</name_singular>
                   <name_plural>root</name_plural>
@@ -8706,10 +7921,6 @@
             </item>
             <item idno="397" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food</name_singular>
-                  <name_plural>food</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>salt</name_singular>
                   <name_plural>salt</name_plural>
@@ -8718,10 +7929,6 @@
             </item>
             <item idno="398" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food</name_singular>
-                  <name_plural>food</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>seaweed</name_singular>
                   <name_plural>seaweed</name_plural>
@@ -8730,14 +7937,6 @@
             </item>
             <item idno="399" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food</name_singular>
-                  <name_plural>food</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>nardoo (Yandruwandha word for a small fern, clover fern)</name_singular>
-                  <name_plural>nardoo (Yandruwandha word for a small fern, clover fern)</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>seed</name_singular>
                   <name_plural>seed</name_plural>
@@ -8750,50 +7949,18 @@
                   <name_singular>shell</name_singular>
                   <name_plural>shell</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>shell bundle, currency</name_singular>
-                  <name_plural>shell bundle, currency</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="401" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food</name_singular>
-                  <name_plural>food</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>shellfish</name_singular>
                   <name_plural>shellfish</name_plural>
                 </label>
               </labels>
             </item>
-            <item idno="633" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>binding</name_singular>
-                  <name_plural>binding</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>kangaroo,</name_singular>
-                  <name_plural>kangaroo,</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>sinew</name_singular>
-                  <name_plural>sinew</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="402" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>brideprice, currency, charm</name_singular>
-                  <name_plural>brideprice, currency, charm</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>rainstone</name_singular>
-                  <name_plural>rainstone</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>stone</name_singular>
                   <name_plural>stone</name_plural>
@@ -8810,10 +7977,6 @@
             </item>
             <item idno="404" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>beeswax, toy</name_singular>
-                  <name_plural>beeswax, toy</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>wax</name_singular>
                   <name_plural>wax</name_plural>
@@ -8825,6 +7988,22 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>wood</name_singular>
                   <name_plural>wood</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="625" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>ochre</name_singular>
+                  <name_plural>ochre</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="633" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>sinew</name_singular>
+                  <name_plural>sinew</name_plural>
                 </label>
               </labels>
             </item>
@@ -8878,18 +8057,6 @@
                 </label>
               </labels>
             </item>
-            <item idno="630" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>circumcision stone</name_singular>
-                  <name_plural>circumcision stone</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>flake, glass</name_singular>
-                  <name_plural>flake, glass</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="411" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
@@ -8922,30 +8089,6 @@
                 </label>
               </labels>
             </item>
-            <item idno="596" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>bullroarer, sacred board, sacred stone, wax figure</name_singular>
-                  <name_plural>bullroarer, sacred board, sacred stone, wax figure</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>love magic</name_singular>
-                  <name_plural>love magic</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="604" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>magic object</name_singular>
-                  <name_plural>magic object</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>stone, bone, shell, wood</name_singular>
-                  <name_plural>stone, bone, shell, wood</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="415" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
@@ -8959,18 +8102,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>message stick</name_singular>
                   <name_plural>message stick</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="631" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>nose bone, hair belt, headdress, feathers</name_singular>
-                  <name_plural>nose bone, hair belt, headdress, feathers</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>ornament</name_singular>
-                  <name_plural>ornament</name_plural>
                 </label>
               </labels>
             </item>
@@ -8990,67 +8121,11 @@
                 </label>
               </labels>
             </item>
-            <item idno="603" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>bone, shell</name_singular>
-                  <name_plural>bone, shell</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>pointing object</name_singular>
-                  <name_plural>pointing object</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>pointing stick, pointing bone</name_singular>
-                  <name_plural>pointing stick, pointing bone</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="594" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>dancing</name_singular>
-                  <name_plural>dancing</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>post</name_singular>
-                  <name_plural>post</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="595" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>rangga</name_singular>
-                  <name_plural>rangga</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="639" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>crayon pencil paper rubbing board bullroarer</name_singular>
-                  <name_plural>crayon pencil paper rubbing board bullroarer</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>rubbing of artefact</name_singular>
-                  <name_plural>rubbing of artefact</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="419" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
                   <name_singular>sacred object</name_singular>
                   <name_plural>sacred object</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="623" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>sorcery or magic item</name_singular>
-                  <name_plural>sorcery or magic item</name_plural>
                 </label>
               </labels>
             </item>
@@ -9064,10 +8139,6 @@
             </item>
             <item idno="421" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>message stick, pointed stick, pointing stick</name_singular>
-                  <name_plural>message stick, pointed stick, pointing stick</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>stick</name_singular>
                   <name_plural>stick</name_plural>
@@ -9079,14 +8150,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>stone</name_singular>
                   <name_plural>stone</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="624" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>string or hair</name_singular>
-                  <name_plural>string or hair</name_plural>
                 </label>
               </labels>
             </item>
@@ -9103,6 +8166,86 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>totem</name_singular>
                   <name_plural>totem</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="594" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>post</name_singular>
+                  <name_plural>post</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="595" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>rangga</name_singular>
+                  <name_plural>rangga</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="596" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>love magic</name_singular>
+                  <name_plural>love magic</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="603" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>pointing object</name_singular>
+                  <name_plural>pointing object</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="604" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>magic object</name_singular>
+                  <name_plural>magic object</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="623" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>sorcery or magic item</name_singular>
+                  <name_plural>sorcery or magic item</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="624" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>string or hair</name_singular>
+                  <name_plural>string or hair</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="630" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>circumcision stone</name_singular>
+                  <name_plural>circumcision stone</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="631" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>ornament</name_singular>
+                  <name_plural>ornament</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="639" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>rubbing of artefact</name_singular>
+                  <name_plural>rubbing of artefact</name_plural>
                 </label>
               </labels>
             </item>
@@ -9126,10 +8269,6 @@
             </item>
             <item idno="426" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>bark bundle</name_singular>
-                  <name_plural>bark bundle</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>body bundle</name_singular>
                   <name_plural>body bundle</name_plural>
@@ -9138,10 +8277,6 @@
             </item>
             <item idno="427" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>all unidentified bones</name_singular>
-                  <name_plural>all unidentified bones</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>bones</name_singular>
                   <name_plural>bones</name_plural>
@@ -9150,10 +8285,6 @@
             </item>
             <item idno="428" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>arm, bust, cranial, dentary, figure, hand, head, leg, torso</name_singular>
-                  <name_plural>arm, bust, cranial, dentary, figure, hand, head, leg, torso</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>cast</name_singular>
                   <name_plural>cast</name_plural>
@@ -9173,10 +8304,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>cranial</name_singular>
                   <name_plural>cranial</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>mandible, maxilla, overmodelled skull, fragments</name_singular>
-                  <name_plural>mandible, maxilla, overmodelled skull, fragments</name_plural>
                 </label>
               </labels>
             </item>
@@ -9198,10 +8325,6 @@
             </item>
             <item idno="433" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>bones misc, arm bone, clavicle, leg bone, humerus, patella, pelvis, radius, scapula, sacrum, ulna, vertebra, femur, fibulae, calvarium</name_singular>
-                  <name_plural>bones misc, arm bone, clavicle, leg bone, humerus, patella, pelvis, radius, scapula, sacrum, ulna, vertebra, femur, fibulae, calvarium</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>post cranial</name_singular>
                   <name_plural>post cranial</name_plural>
@@ -9210,10 +8333,6 @@
             </item>
             <item idno="434" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>hair sample, shrunkenhead, mummified object</name_singular>
-                  <name_plural>hair sample, shrunkenhead, mummified object</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>preserved body part</name_singular>
                   <name_plural>preserved body part</name_plural>
@@ -9246,35 +8365,19 @@
             </label>
           </labels>
           <items>
+            <item idno="393" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>needle</name_singular>
+                  <name_plural>needle</name_plural>
+                </label>
+              </labels>
+            </item>
             <item idno="437" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
                   <name_singular>bark cloth</name_singular>
                   <name_plural>bark cloth</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>bark cloth, sample</name_singular>
-                  <name_plural>bark cloth, sample</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>tapa</name_singular>
-                  <name_plural>tapa</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="439" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>bark cloth beater</name_singular>
-                  <name_plural>bark cloth beater</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>tapa</name_singular>
-                  <name_plural>tapa</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>tapa beater</name_singular>
-                  <name_plural>tapa beater</name_plural>
                 </label>
               </labels>
             </item>
@@ -9286,15 +8389,11 @@
                 </label>
               </labels>
             </item>
-            <item idno="644" enabled="1" default="0">
+            <item idno="439" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
-                  <name_singular>beaded fabric</name_singular>
-                  <name_plural>beaded fabric</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>beaded panel</name_singular>
-                  <name_plural>beaded panel</name_plural>
+                  <name_singular>bark cloth beater</name_singular>
+                  <name_plural>bark cloth beater</name_plural>
                 </label>
               </labels>
             </item>
@@ -9330,14 +8429,6 @@
                 </label>
               </labels>
             </item>
-            <item idno="460" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>flax cloth</name_singular>
-                  <name_plural>flax cloth</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="444" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
@@ -9368,18 +8459,10 @@
                   <name_singular>loom</name_singular>
                   <name_plural>loom</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>weaving loom</name_singular>
-                  <name_plural>weaving loom</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="448" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>doily, tablemat</name_singular>
-                  <name_plural>doily, tablemat</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>mat</name_singular>
                   <name_plural>mat</name_plural>
@@ -9391,14 +8474,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>mat making stick</name_singular>
                   <name_plural>mat making stick</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="393" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>needle</name_singular>
-                  <name_plural>needle</name_plural>
                 </label>
               </labels>
             </item>
@@ -9423,14 +8498,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>punch</name_singular>
                   <name_plural>punch</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="628" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>rug</name_singular>
-                  <name_plural>rug</name_plural>
                 </label>
               </labels>
             </item>
@@ -9468,10 +8535,6 @@
             </item>
             <item idno="457" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>block</name_singular>
-                  <name_plural>block</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>stamp</name_singular>
                   <name_plural>stamp</name_plural>
@@ -9486,36 +8549,48 @@
                 </label>
               </labels>
             </item>
-            <item idno="597" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>string</name_singular>
-                  <name_plural>string</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>wool, twine, silk, rope</name_singular>
-                  <name_plural>wool, twine, silk, rope</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="459" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>ceremonial</name_singular>
-                  <name_plural>ceremonial</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>textile</name_singular>
                   <name_plural>textile</name_plural>
                 </label>
               </labels>
             </item>
+            <item idno="460" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>flax cloth</name_singular>
+                  <name_plural>flax cloth</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="597" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>string</name_singular>
+                  <name_plural>string</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="628" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>rug</name_singular>
+                  <name_plural>rug</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="644" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>beaded fabric</name_singular>
+                  <name_plural>beaded fabric</name_plural>
+                </label>
+              </labels>
+            </item>
             <item idno="652" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>batik, cloth</name_singular>
-                  <name_plural>batik, cloth</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>wax pourer</name_singular>
                   <name_plural>wax pourer</name_plural>
@@ -9562,10 +8637,6 @@
                   <name_singular>puppet</name_singular>
                   <name_plural>puppet</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>shadow, rangda, barong,</name_singular>
-                  <name_plural>shadow, rangda, barong,</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="466" enabled="1" default="0">
@@ -9600,10 +8671,6 @@
                   <name_singular>adze</name_singular>
                   <name_plural>adze</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>haft, socket, blade</name_singular>
-                  <name_plural>haft, socket, blade</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="469" enabled="1" default="0">
@@ -9611,10 +8678,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>anvil</name_singular>
                   <name_plural>anvil</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>metal,log, stone</name_singular>
-                  <name_plural>metal,log, stone</name_plural>
                 </label>
               </labels>
             </item>
@@ -9632,18 +8695,10 @@
                   <name_singular>axe</name_singular>
                   <name_plural>axe</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>ceremonial</name_singular>
-                  <name_plural>ceremonial</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="472" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>(not fishing, see HFW)</name_singular>
-                  <name_plural>(not fishing, see HFW)</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>beater</name_singular>
                   <name_plural>beater</name_plural>
@@ -9663,10 +8718,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>breadfruit splitter</name_singular>
                   <name_plural>breadfruit splitter</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food preparation</name_singular>
-                  <name_plural>food preparation</name_plural>
                 </label>
               </labels>
             </item>
@@ -9708,10 +8759,6 @@
                   <name_singular>coconut husker</name_singular>
                   <name_plural>coconut husker</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food preparation</name_singular>
-                  <name_plural>food preparation</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="480" enabled="1" default="0">
@@ -9728,29 +8775,13 @@
                   <name_singular>cord</name_singular>
                   <name_plural>cord</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>cordage, string</name_singular>
-                  <name_plural>cordage, string</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>medical</name_singular>
-                  <name_plural>medical</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="482" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>digging or ceremonial implement</name_singular>
-                  <name_plural>digging or ceremonial implement</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>digging stick</name_singular>
                   <name_plural>digging stick</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food preparation</name_singular>
-                  <name_plural>food preparation</name_plural>
                 </label>
               </labels>
             </item>
@@ -9764,10 +8795,6 @@
             </item>
             <item idno="484" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>bow, pump, borer</name_singular>
-                  <name_plural>bow, pump, borer</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>drill</name_singular>
                   <name_plural>drill</name_plural>
@@ -9787,10 +8814,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>file</name_singular>
                   <name_plural>file</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>rasp</name_singular>
-                  <name_plural>rasp</name_plural>
                 </label>
               </labels>
             </item>
@@ -9824,41 +8847,13 @@
                   <name_singular>hammer</name_singular>
                   <name_plural>hammer</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>hammerstone, mallet</name_singular>
-                  <name_plural>hammerstone, mallet</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="634" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>headpad</name_singular>
-                  <name_plural>headpad</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>manguri, head ring</name_singular>
-                  <name_plural>manguri, head ring</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="491" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food preparation</name_singular>
-                  <name_plural>food preparation</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>hoe</name_singular>
                   <name_plural>hoe</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="651" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>husker</name_singular>
-                  <name_plural>husker</name_plural>
                 </label>
               </labels>
             </item>
@@ -9876,30 +8871,10 @@
                   <name_singular>lancet</name_singular>
                   <name_plural>lancet</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>medical</name_singular>
-                  <name_plural>medical</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="635" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>lice remover</name_singular>
-                  <name_plural>lice remover</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>pointed stick, lice, grooming</name_singular>
-                  <name_plural>pointed stick, lice, grooming</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="494" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>bender</name_singular>
-                  <name_plural>bender</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>moulding device</name_singular>
                   <name_plural>moulding device</name_plural>
@@ -9908,10 +8883,6 @@
             </item>
             <item idno="495" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>crotchet hook, sewing</name_singular>
-                  <name_plural>crotchet hook, sewing</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>needle</name_singular>
                   <name_plural>needle</name_plural>
@@ -9928,25 +8899,9 @@
             </item>
             <item idno="497" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food preparation</name_singular>
-                  <name_plural>food preparation</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>plough</name_singular>
                   <name_plural>plough</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="593" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>bone, stone, metal</name_singular>
-                  <name_plural>bone, stone, metal</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>point</name_singular>
-                  <name_plural>point</name_plural>
                 </label>
               </labels>
             </item>
@@ -9963,18 +8918,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>pot smoother</name_singular>
                   <name_plural>pot smoother</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="632" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>bone, metal</name_singular>
-                  <name_plural>bone, metal</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>pressure flaking tool</name_singular>
-                  <name_plural>pressure flaking tool</name_plural>
                 </label>
               </labels>
             </item>
@@ -9999,14 +8942,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>rope</name_singular>
                   <name_plural>rope</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>sennit,</name_singular>
-                  <name_plural>sennit,</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>sinnet</name_singular>
-                  <name_plural>sinnet</name_plural>
                 </label>
               </labels>
             </item>
@@ -10040,10 +8975,6 @@
                   <name_singular>set</name_singular>
                   <name_plural>set</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>sharpener</name_singular>
-                  <name_plural>sharpener</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="507" enabled="1" default="0">
@@ -10056,10 +8987,6 @@
             </item>
             <item idno="508" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food preparation</name_singular>
-                  <name_plural>food preparation</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>shovel</name_singular>
                   <name_plural>shovel</name_plural>
@@ -10068,10 +8995,6 @@
             </item>
             <item idno="509" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>food preparation</name_singular>
-                  <name_plural>food preparation</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>sickle</name_singular>
                   <name_plural>sickle</name_plural>
@@ -10088,15 +9011,7 @@
             </item>
             <item idno="511" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>bark</name_singular>
-                  <name_plural>bark</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
-                  <name_singular>splitter</name_singular>
-                  <name_plural>splitter</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
                   <name_singular>splitter</name_singular>
                   <name_plural>splitter</name_plural>
                 </label>
@@ -10124,18 +9039,10 @@
                   <name_singular>tool</name_singular>
                   <name_plural>tool</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>uni-point, toggle, bi-point</name_singular>
-                  <name_plural>uni-point, toggle, bi-point</name_plural>
-                </label>
               </labels>
             </item>
             <item idno="515" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>medical</name_singular>
-                  <name_plural>medical</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>trephining tool</name_singular>
                   <name_plural>trephining tool</name_plural>
@@ -10158,6 +9065,46 @@
                 </label>
               </labels>
             </item>
+            <item idno="593" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>point</name_singular>
+                  <name_plural>point</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="632" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>pressure flaking tool</name_singular>
+                  <name_plural>pressure flaking tool</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="634" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>headpad</name_singular>
+                  <name_plural>headpad</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="635" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>lice remover</name_singular>
+                  <name_plural>lice remover</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="651" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>husker</name_singular>
+                  <name_plural>husker</name_plural>
+                </label>
+              </labels>
+            </item>
           </items>
         </item>
         <item idno="TOY" enabled="1" default="0">
@@ -10168,66 +9115,6 @@
             </label>
           </labels>
           <items>
-            <item idno="681" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>armour</name_singular>
-                  <name_plural>armour</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>military toy</name_singular>
-                  <name_plural>military toy</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>paper toy</name_singular>
-                  <name_plural>paper toy</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="627" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>axe</name_singular>
-                  <name_plural>axe</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="520" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>ball</name_singular>
-                  <name_plural>ball</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="605" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>boat</name_singular>
-                  <name_plural>boat</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>raft, canoe</name_singular>
-                  <name_plural>raft, canoe</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="607" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>boomerang</name_singular>
-                  <name_plural>boomerang</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="608" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>club</name_singular>
-                  <name_plural>club</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="518" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
@@ -10242,9 +9129,13 @@
                   <name_singular>counter</name_singular>
                   <name_plural>counter</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>token</name_singular>
-                  <name_plural>token</name_plural>
+              </labels>
+            </item>
+            <item idno="520" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>ball</name_singular>
+                  <name_plural>ball</name_plural>
                 </label>
               </labels>
             </item>
@@ -10317,18 +9208,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>rattle</name_singular>
                   <name_plural>rattle</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="636" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>roller</name_singular>
-                  <name_plural>roller</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>truck</name_singular>
-                  <name_plural>truck</name_plural>
                 </label>
               </labels>
             </item>
@@ -10412,23 +9291,67 @@
                 </label>
               </labels>
             </item>
+            <item idno="540" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>weetweet</name_singular>
+                  <name_plural>weetweet</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="605" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>boat</name_singular>
+                  <name_plural>boat</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="607" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>boomerang</name_singular>
+                  <name_plural>boomerang</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="608" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>club</name_singular>
+                  <name_plural>club</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="627" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>axe</name_singular>
+                  <name_plural>axe</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="636" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>roller</name_singular>
+                  <name_plural>roller</name_plural>
+                </label>
+              </labels>
+            </item>
             <item idno="641" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>truck car bus</name_singular>
-                  <name_plural>truck car bus</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>vehicle</name_singular>
                   <name_plural>vehicle</name_plural>
                 </label>
               </labels>
             </item>
-            <item idno="540" enabled="1" default="0">
+            <item idno="681" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
-                  <name_singular>weetweet</name_singular>
-                  <name_plural>weetweet</name_plural>
+                  <name_singular>armour</name_singular>
+                  <name_plural>armour</name_plural>
                 </label>
               </labels>
             </item>
@@ -10464,18 +9387,18 @@
                   <name_singular>boat</name_singular>
                   <name_plural>boat</name_plural>
                 </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>model</name_singular>
-                  <name_plural>model</name_plural>
+              </labels>
+            </item>
+            <item idno="544" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>cart</name_singular>
+                  <name_plural>cart</name_plural>
                 </label>
               </labels>
             </item>
             <item idno="545" enabled="1" default="0">
               <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>bark, dugout, outrigger</name_singular>
-                  <name_plural>bark, dugout, outrigger</name_plural>
-                </label>
                 <label locale="en_AU" preferred="1">
                   <name_singular>canoe</name_singular>
                   <name_plural>canoe</name_plural>
@@ -10554,14 +9477,6 @@
                 </label>
               </labels>
             </item>
-            <item idno="544" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>cart</name_singular>
-                  <name_plural>cart</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="555" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
@@ -10570,19 +9485,19 @@
                 </label>
               </labels>
             </item>
-            <item idno="557" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>float</name_singular>
-                  <name_plural>float</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="556" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
                   <name_singular>fragment</name_singular>
                   <name_plural>fragment</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="557" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>float</name_singular>
+                  <name_plural>float</name_plural>
                 </label>
               </labels>
             </item>
@@ -10610,23 +9525,19 @@
                 </label>
               </labels>
             </item>
-            <item idno="562" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>oar, primary, secondary, steering</name_singular>
-                  <name_plural>oar, primary, secondary, steering</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>paddle</name_singular>
-                  <name_plural>paddle</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="561" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
                   <name_singular>prow</name_singular>
                   <name_plural>prow</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="562" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>paddle</name_singular>
+                  <name_plural>paddle</name_plural>
                 </label>
               </labels>
             </item>
@@ -10670,22 +9581,6 @@
                 </label>
               </labels>
             </item>
-            <item idno="655" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>saddle bag</name_singular>
-                  <name_plural>saddle bag</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="659" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>saddle tree</name_singular>
-                  <name_plural>saddle tree</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="568" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
@@ -10699,6 +9594,22 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>set</name_singular>
                   <name_plural>set</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="655" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>saddle bag</name_singular>
+                  <name_plural>saddle bag</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="659" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>saddle tree</name_singular>
+                  <name_plural>saddle tree</name_plural>
                 </label>
               </labels>
             </item>
@@ -10802,47 +9713,11 @@
             </label>
           </labels>
           <items>
-            <item idno="671" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>bookmark</name_singular>
-                  <name_plural>bookmark</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="677" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>card</name_singular>
-                  <name_plural>card</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>gift card</name_singular>
-                  <name_plural>gift card</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="580" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
                   <name_singular>cassette</name_singular>
                   <name_plural>cassette</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="602" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>cd, dvd, minidisc</name_singular>
-                  <name_plural>cd, dvd, minidisc</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>compact disc</name_singular>
-                  <name_plural>compact disc</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>music, audio</name_singular>
-                  <name_plural>music, audio</name_plural>
                 </label>
               </labels>
             </item>
@@ -10870,35 +9745,11 @@
                 </label>
               </labels>
             </item>
-            <item idno="601" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>flyer</name_singular>
-                  <name_plural>flyer</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>pamphlet</name_singular>
-                  <name_plural>pamphlet</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="584" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
                   <name_singular>photo album</name_singular>
                   <name_plural>photo album</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="586" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>historic, archival</name_singular>
-                  <name_plural>historic, archival</name_plural>
-                </label>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>photograph</name_singular>
-                  <name_plural>photograph</name_plural>
                 </label>
               </labels>
             </item>
@@ -10910,15 +9761,19 @@
                 </label>
               </labels>
             </item>
+            <item idno="586" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>photograph</name_singular>
+                  <name_plural>photograph</name_plural>
+                </label>
+              </labels>
+            </item>
             <item idno="587" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
                   <name_singular>poster</name_singular>
                   <name_plural>poster</name_plural>
-                </label>
-                <label locale="en_AU" preferred="0">
-                  <name_singular>print (i.e. reproduction</name_singular>
-                  <name_plural>print (i.e. reproduction</name_plural>
                 </label>
               </labels>
             </item>
@@ -10946,14 +9801,6 @@
                 </label>
               </labels>
             </item>
-            <item idno="674" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>snow globe</name_singular>
-                  <name_plural>snow globe</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="591" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
@@ -10967,6 +9814,46 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>video</name_singular>
                   <name_plural>video</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="601" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>pamphlet</name_singular>
+                  <name_plural>pamphlet</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="602" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>compact disc</name_singular>
+                  <name_plural>compact disc</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="671" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>bookmark</name_singular>
+                  <name_plural>bookmark</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="674" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>snow globe</name_singular>
+                  <name_plural>snow globe</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="677" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>card</name_singular>
+                  <name_plural>card</name_plural>
                 </label>
               </labels>
             </item>
@@ -10986,22 +9873,6 @@
             <label locale="en_AU" preferred="1">
               <name_singular>Example Audit Procedure</name_singular>
               <name_plural>Example Audit Procedures</name_plural>
-            </label>
-          </labels>
-        </item>
-        <item idno="2" enabled="1" default="0" value="2">
-          <labels>
-            <label locale="en_AU" preferred="1">
-              <name_singular>2</name_singular>
-              <name_plural>2</name_plural>
-            </label>
-          </labels>
-        </item>
-        <item idno="3" enabled="1" default="0" value="3">
-          <labels>
-            <label locale="en_AU" preferred="1">
-              <name_singular>3</name_singular>
-              <name_plural>3</name_plural>
             </label>
           </labels>
         </item>
@@ -11872,27 +10743,11 @@
             </label>
           </labels>
         </item>
-        <item idno="6" enabled="1" default="0" value="6">
-          <labels>
-            <label locale="en_AU" preferred="1">
-              <name_singular>6</name_singular>
-              <name_plural>6</name_plural>
-            </label>
-          </labels>
-        </item>
         <item idno="W" enabled="1" default="0">
           <labels>
             <label locale="en_AU" preferred="1">
               <name_singular>W</name_singular>
               <name_plural>W</name_plural>
-            </label>
-          </labels>
-        </item>
-        <item idno="4" enabled="1" default="0" value="4">
-          <labels>
-            <label locale="en_AU" preferred="1">
-              <name_singular>4</name_singular>
-              <name_plural>4</name_plural>
             </label>
           </labels>
         </item>
@@ -16656,15 +15511,7 @@ http://palaeontology.palass-pubs.org/pdf/Vol%2031/Pages%20223-227.pdf2011.</desc
         <restriction>
           <table>ca_list_items</table>
           <type>scientific_name</type>
-          <settings>
-            <setting name="minAttributesPerRow">1</setting>
-            <setting name="maxAttributesPerRow">1</setting>
-            <setting name="minimumAttributeBundlesToDisplay">1</setting>
-          </settings>
-        </restriction>
-        <restriction>
-          <table>ca_occurrences</table>
-          <type>resource</type>
+          <includeSubtypes>1</includeSubtypes>
           <settings>
             <setting name="minAttributesPerRow">1</setting>
             <setting name="maxAttributesPerRow">1</setting>
@@ -16688,6 +15535,7 @@ http://palaeontology.palass-pubs.org/pdf/Vol%2031/Pages%20223-227.pdf2011.</desc
         <restriction>
           <table>ca_list_items</table>
           <type>scientific_name</type>
+          <includeSubtypes>1</includeSubtypes>
           <settings>
             <setting name="minAttributesPerRow">0</setting>
             <setting name="maxAttributesPerRow">0</setting>
@@ -16796,15 +15644,6 @@ http://palaeontology.palass-pubs.org/pdf/Vol%2031/Pages%20223-227.pdf2011.</desc
         <restriction>
           <table>ca_list_items</table>
           <type>scientific_name</type>
-          <settings>
-            <setting name="minAttributesPerRow">0</setting>
-            <setting name="maxAttributesPerRow">1</setting>
-            <setting name="minimumAttributeBundlesToDisplay">1</setting>
-          </settings>
-        </restriction>
-        <restriction>
-          <table>ca_occurrences</table>
-          <type/>
           <includeSubtypes>1</includeSubtypes>
           <settings>
             <setting name="minAttributesPerRow">0</setting>
@@ -17248,6 +16087,7 @@ Examples: "mm", "C", "km", "ha".</description>
         <restriction>
           <table>ca_list_items</table>
           <type>scientific_name</type>
+          <includeSubtypes>1</includeSubtypes>
           <settings>
             <setting name="minAttributesPerRow">0</setting>
             <setting name="maxAttributesPerRow">1</setting>
@@ -19997,8 +18837,7 @@ Example: "Quercus alba". For discussion see http://code.google.com/p/darwincore/
       <typeRestrictions>
         <restriction>
           <table>ca_list_items</table>
-          <type>scientific_name</type>
-          <includeSubtypes>1</includeSubtypes>
+          <type>family</type>
           <settings>
             <setting name="minAttributesPerRow">0</setting>
             <setting name="maxAttributesPerRow">1</setting>
@@ -21607,13 +20446,6 @@ Example: "Quercus alba". For discussion see http://code.google.com/p/darwincore/
                 <setting name="maxRelationshipsPerRow"/>
               </settings>
             </placement>
-            <placement code="hierarchy_location1">
-              <bundle>hierarchy_location</bundle>
-              <settings>
-                <setting name="open_hierarchy"/>
-                <setting name="readonly"/>
-              </settings>
-            </placement>
             <placement code="source_id">
               <bundle>source_id</bundle>
               <settings>
@@ -23180,6 +22012,25 @@ Lent to: &lt;unit relativeTo="ca_loans"&gt;&#13;
       </labels>
       <typeRestrictions>
         <restriction type="scientific_name"/>
+        <restriction type="class"/>
+        <restriction type="cohort"/>
+        <restriction type="family"/>
+        <restriction type="infraorder"/>
+				<restriction type="suborder"/>
+        <restriction type="kingdom"/>
+        <restriction type="order"/>
+        <restriction type="phylum"/>
+        <restriction type="species"/>
+        <restriction type="subclass"/>
+        <restriction type="subfamily"/>
+				<restriction type="genus"/>
+        <restriction type="subgenus"/>
+        <restriction type="infraorder"/>
+        <restriction type="subphylum"/>
+        <restriction type="subspecies"/>
+        <restriction type="superfamily"/>
+        <restriction type="superorder"/>
+        <restriction type="tribe"/>
       </typeRestrictions>
       <userAccess>
         <permission user="administrator" access="edit"/>
@@ -23262,6 +22113,10 @@ e.g. "Malacostraca", "Canis lupus".</setting>
             </placement>
             <placement code="ca_attribute_caabFamilyNo8">
               <bundle>ca_attribute_caabFamilyNo</bundle>
+              <settings>
+                <setting name="readonly"/>
+                <setting name="sortDirection">ASC</setting>
+              </settings>
             </placement>
             <placement code="is_enabled8">
               <bundle>is_enabled</bundle>
@@ -25122,6 +23977,24 @@ Loaned to: &lt;unit relativeTo="ca_loans"&gt;&#13;
                 <setting name="readonly"/>
                 <setting name="restrict_to_relationship_types">identification</setting>
                 <setting name="restrict_to_types">scientific_name</setting>
+                <setting name="restrict_to_types">kingdom</setting>
+                <setting name="restrict_to_types">phylum</setting>
+                <setting name="restrict_to_types">subphylum</setting>
+                <setting name="restrict_to_types">class</setting>
+                <setting name="restrict_to_types">subclass</setting>
+                <setting name="restrict_to_types">cohort</setting>
+                <setting name="restrict_to_types">superorder</setting>
+                <setting name="restrict_to_types">order</setting>
+                <setting name="restrict_to_types">infraorder</setting>
+                <setting name="restrict_to_types">suborder</setting>
+                <setting name="restrict_to_types">superfamily</setting>
+                <setting name="restrict_to_types">family</setting>
+                <setting name="restrict_to_types">subfamily</setting>
+                <setting name="restrict_to_types">tribe</setting>
+								<setting name="restrict_to_types">genus</setting>
+                <setting name="restrict_to_types">subgenus</setting>
+                <setting name="restrict_to_types">species</setting>
+                <setting name="restrict_to_types">subspecies</setting>
                 <setting name="dont_include_subtypes_in_type_restriction">0</setting>
                 <setting name="list_format">bubbles</setting>
                 <setting name="sortDirection">ASC</setting>
@@ -25950,8 +24823,8 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <type code="discover" default="0">
           <labels>
             <label locale="en_AU">
-              <typename>was discovered by</typename>
-              <typename_reverse>discovered</typename_reverse>
+              <typename>was discovered / collected by</typename>
+              <typename_reverse>discovered / collected</typename_reverse>
             </label>
           </labels>
         </type>
@@ -26187,7 +25060,6 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
               <typename_reverse>is determined name for</typename_reverse>
             </label>
           </labels>
-          <subTypeRight>scientific_name</subTypeRight>
         </type>
         <type code="associated" default="0">
           <labels>
@@ -26498,7 +25370,6 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
             </label>
           </labels>
           <subTypeLeft>ind</subTypeLeft>
-          <subTypeRight>scientific_name</subTypeRight>
         </type>
       </types>
     </relationshipTable>
@@ -27183,8 +26054,6 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_etAl" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_measurementOrFact" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_namePublishedInYear" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_taxonRank" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_minimumDepthInMeters" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_substrate" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_rft_pages" access="edit"/>
@@ -27845,8 +26714,6 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_etAl" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_measurementOrFact" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_namePublishedInYear" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_taxonRank" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_minimumDepthInMeters" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_substrate" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_rft_pages" access="edit"/>
@@ -28554,8 +27421,6 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_etAl" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_measurementOrFact" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_namePublishedInYear" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_taxonRank" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_minimumDepthInMeters" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_substrate" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_rft_pages" access="edit"/>
@@ -29293,7 +28158,6 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_minDistAboveSurface" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_minimumDepthInMeters" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_minimumElevationInMeters" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_namePublishedInYear" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_noPages" access="none"/>
         <permission table="ca_occurrences" bundle="nonpreferred_labels" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_occurrenceDetails" access="none"/>
@@ -29319,7 +28183,6 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="source_id" access="none"/>
         <permission table="ca_occurrences" bundle="status" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_substrate" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_taxonRank" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_typeStatus" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_verbatimDepth" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_verbatimElevation" access="none"/>
@@ -30013,140 +28876,6 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         </placement>
       </bundlePlacements>
     </display>
-    <display code="occurrenceIdentification" type="ca_occurrences" system="1">
-      <labels>
-        <label locale="en_AU">
-          <name>Identification</name>
-        </label>
-      </labels>
-      <settings>
-        <setting name="show_empty_values">1</setting>
-      </settings>
-      <userAccess>
-        <permission user="administrator" access="edit"/>
-      </userAccess>
-      <groupAccess>
-        <permission group="cataloguer" access="read"/>
-        <permission group="admin" access="edit"/>
-      </groupAccess>
-      <bundlePlacements>
-        <placement code="ca_occurrences_type_id">
-          <bundle>ca_occurrences.type_id</bundle>
-          <settings>
-            <setting name="label" locale="en_AU"/>
-          </settings>
-        </placement>
-        <placement code="ca_objects">
-          <bundle>ca_objects</bundle>
-          <settings>
-            <setting name="label" locale="en_AU"/>
-            <setting name="format"/>
-            <setting name="delimiter"/>
-            <setting name="remove_first_items">0</setting>
-            <setting name="hierarchy_order">ASC</setting>
-            <setting name="hierarchy_limit">0</setting>
-            <setting name="hierarchical_delimiter"> ➔ </setting>
-          </settings>
-        </placement>
-        <placement code="ca_list_items">
-          <bundle>ca_list_items</bundle>
-          <settings>
-            <setting name="label" locale="en_AU"/>
-            <setting name="format"/>
-            <setting name="restrict_to_types">228</setting>
-            <setting name="delimiter"/>
-            <setting name="show_hierarchy">1</setting>
-            <setting name="remove_first_items">0</setting>
-            <setting name="hierarchy_order">ASC</setting>
-            <setting name="hierarchy_limit">0</setting>
-            <setting name="hierarchical_delimiter"> ➔ </setting>
-          </settings>
-        </placement>
-        <placement code="ca_occurrences_scientificName">
-          <bundle>ca_occurrences.scientificName</bundle>
-          <settings>
-            <setting name="label" locale="en_AU"/>
-            <setting name="format">^label: &lt;em&gt;^scientificName&lt;/em&gt;</setting>
-            <setting name="delimiter"/>
-            <setting name="maximum_length">2048</setting>
-            <setting name="sense">singular</setting>
-          </settings>
-        </placement>
-        <placement code="ca_entities">
-          <bundle>ca_entities</bundle>
-          <settings>
-            <setting name="label" locale="en_AU">Identified By</setting>
-            <setting name="makeEditorLink">1</setting>
-            <setting name="format"/>
-            <setting name="restrict_to_relationship_types">180</setting>
-            <setting name="restrict_to_types">75</setting>
-            <setting name="delimiter"/>
-            <setting name="remove_first_items">0</setting>
-            <setting name="hierarchy_order">ASC</setting>
-            <setting name="hierarchy_limit">0</setting>
-            <setting name="hierarchical_delimiter"> ➔ </setting>
-          </settings>
-        </placement>
-        <placement code="ca_occurrences_etAl">
-          <bundle>ca_occurrences.etAl</bundle>
-          <settings>
-            <setting name="label" locale="en_AU"/>
-            <setting name="format"/>
-            <setting name="delimiter"/>
-            <setting name="maximum_length">2048</setting>
-            <setting name="sense">singular</setting>
-          </settings>
-        </placement>
-        <placement code="ca_occurrences_dateIdentified">
-          <bundle>ca_occurrences.dateIdentified</bundle>
-          <settings>
-            <setting name="label" locale="en_AU"/>
-            <setting name="format"/>
-            <setting name="delimiter"/>
-            <setting name="maximum_length">2048</setting>
-          </settings>
-        </placement>
-        <placement code="ca_occurrences_identificationQualifier">
-          <bundle>ca_occurrences.identificationQualifier</bundle>
-          <settings>
-            <setting name="label" locale="en_AU"/>
-            <setting name="format"/>
-            <setting name="delimiter"/>
-            <setting name="maximum_length">2048</setting>
-            <setting name="sense">singular</setting>
-          </settings>
-        </placement>
-        <placement code="ca_occurrences_identificationRemarks">
-          <bundle>ca_occurrences.identificationRemarks</bundle>
-          <settings>
-            <setting name="label" locale="en_AU"/>
-            <setting name="format"/>
-            <setting name="delimiter"/>
-            <setting name="maximum_length">2048</setting>
-          </settings>
-        </placement>
-        <placement code="ca_occurrences_idVerificationStatus">
-          <bundle>ca_occurrences.idVerificationStatus</bundle>
-          <settings>
-            <setting name="label" locale="en_AU"/>
-            <setting name="format"/>
-            <setting name="delimiter"/>
-            <setting name="maximum_length">2048</setting>
-            <setting name="sense">singular</setting>
-          </settings>
-        </placement>
-        <placement code="ca_occurrences_typeStatus">
-          <bundle>ca_occurrences.typeStatus</bundle>
-          <settings>
-            <setting name="label" locale="en_AU"/>
-            <setting name="format"/>
-            <setting name="delimiter"/>
-            <setting name="maximum_length">2048</setting>
-            <setting name="sense">singular</setting>
-          </settings>
-        </placement>
-      </bundlePlacements>
-    </display>
     <display code="dwc_display" type="ca_objects" system="1">
       <labels>
         <label locale="en_AU">
@@ -30184,13 +28913,30 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
           <settings>
             <setting name="label" locale="en_AU">Determined Scientific Name</setting>
             <setting name="format"/>
-            <setting name="restrict_to_relationship_types">200</setting>
+            <setting name="restrict_to_relationship_types">identification</setting>
             <setting name="restrict_to_types">228</setting>
+            <setting name="restrict_to_types">82119</setting>
+            <setting name="restrict_to_types">82120</setting>
+            <setting name="restrict_to_types">82121</setting>
+            <setting name="restrict_to_types">82122</setting>
+            <setting name="restrict_to_types">82123</setting>
+            <setting name="restrict_to_types">82124</setting>
+            <setting name="restrict_to_types">82125</setting>
+            <setting name="restrict_to_types">82126</setting>
+            <setting name="restrict_to_types">82127</setting>
+            <setting name="restrict_to_types">82128</setting>
+            <setting name="restrict_to_types">82129</setting>
+            <setting name="restrict_to_types">82130</setting>
+            <setting name="restrict_to_types">82131</setting>
+            <setting name="restrict_to_types">82132</setting>
+            <setting name="restrict_to_types">82133</setting>
+            <setting name="restrict_to_types">82134</setting>
+            <setting name="restrict_to_types">82135</setting>
             <setting name="delimiter"/>
             <setting name="show_hierarchy">1</setting>
             <setting name="remove_first_items">2</setting>
             <setting name="hierarchy_order">ASC</setting>
-            <setting name="hierarchy_limit">0</setting>
+            <setting name="hierarchy_limit">5</setting>
             <setting name="hierarchical_delimiter"> ➔ </setting>
           </settings>
         </placement>
@@ -30287,6 +29033,8 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
             <setting name="hierarchy_order">ASC</setting>
             <setting name="hierarchy_limit">0</setting>
             <setting name="hierarchical_delimiter"> ➔ </setting>
+            <setting name="restrict_to_relationship_types"/>
+            <setting name="restrict_to_types"/>
           </settings>
         </placement>
         <placement code="ca_objects_acquisition_type_id">
@@ -30300,6 +29048,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
           <bundle>ca_objects.source_id</bundle>
           <settings>
             <setting name="label" locale="en_AU"/>
+            <setting name="maximum_length">100</setting>
           </settings>
         </placement>
         <placement code="ca_objects_associatedSequences">

--- a/install/profiles/xml/wamcmis.xml
+++ b/install/profiles/xml/wamcmis.xml
@@ -32,6 +32,162 @@
               <name_plural>Taxon Names</name_plural>
             </label>
           </labels>
+					<items>
+						<item idno="kingdom" enabled="1" default="0">
+							<labels>
+								<label locale="en_AU" preferred="1">
+									<name_singular>Kingdom</name_singular>
+									<name_plural>Kingdoms</name_plural>
+								</label>
+							</labels>
+							<items>
+								<item idno="phylum" enabled="1" default="0">
+									<labels>
+										<label locale="en_AU" preferred="1">
+											<name_singular>phylum</name_singular>
+											<name_plural>phylum</name_plural>
+										</label>
+									</labels>
+									<items>
+										<item idno="subphylum" enabled="1" default="0">
+											<labels>
+												<label locale="en_AU" preferred="1">
+													<name_singular>Subphylum</name_singular>
+													<name_plural>Subphylum</name_plural>
+												</label>
+											</labels>
+											<items>
+												<item idno="class" enabled="1" default="0">
+													<labels>
+														<label locale="en_AU" preferred="1">
+															<name_singular>Class</name_singular>
+															<name_plural>Class</name_plural>
+														</label>
+													</labels>
+													<items>
+														<item idno="subclass" enabled="1" default="0">
+															<labels>
+																<label locale="en_AU" preferred="1">
+																	<name_singular>Subclass</name_singular>
+																	<name_plural>Subclasses</name_plural>
+																</label>
+															</labels>
+															<items>
+																<item idno="cohort" enabled="1" default="0">
+																	<labels>
+																		<label locale="en_AU" preferred="1">
+																			<name_singular>Cohort</name_singular>
+																			<name_plural>Cohorts</name_plural>
+																		</label>
+																	</labels>
+																	<items>
+																		<item idno="superorder" enabled="1" default="0">
+																			<labels>
+																				<label locale="en_AU" preferred="1">
+																					<name_singular>Superorder</name_singular>
+																					<name_plural>Superorders</name_plural>
+																				</label>
+																			</labels>
+																			<items>
+																				<item idno="order" enabled="1" default="0">
+																					<labels>
+																						<label locale="en_AU" preferred="1">
+																							<name_singular>Order</name_singular>
+																							<name_plural>Orders</name_plural>
+																						</label>
+																					</labels>
+																					<items>
+																						<item idno="infraorder" enabled="1" default="0">
+																							<labels>
+																								<label locale="en_AU" preferred="1">
+																									<name_singular>Infraorder</name_singular>
+																									<name_plural>Infraorders</name_plural>
+																								</label>
+																							</labels>
+																							<items>
+																								<item idno="suborder" enabled="1" default="0">
+																									<labels>
+																										<label locale="en_AU" preferred="1">
+																											<name_singular>Suborder</name_singular>
+																											<name_plural>Suborders</name_plural>
+																										</label>
+																									</labels>
+																									<items>
+																										<item idno="superfamily" enabled="1" default="0">
+																											<labels>
+																												<label locale="en_AU" preferred="1">
+																													<name_singular>Superfamily</name_singular>
+																													<name_plural>Superfamily</name_plural>
+																												</label>
+																											</labels>
+																											<items>
+																												<item idno="family" enabled="1" default="0">
+																													<labels>
+																														<label locale="en_AU" preferred="1">
+																															<name_singular>Family</name_singular>
+																															<name_plural>Families</name_plural>
+																														</label>
+																													</labels>
+																													<items>
+																														<item idno="subfamily" enabled="1" default="0">
+																															<labels>
+																																<label locale="en_AU" preferred="1">
+																																	<name_singular>Subfamily</name_singular>
+																																	<name_plural>Subfamilies</name_plural>
+																																</label>
+																															</labels>
+																															<items>
+																																<item idno="subfamily" enabled="1" default="0">
+																																	<labels>
+																																		<label locale="en_AU" preferred="1">
+																																			<name_singular>Subfamily</name_singular>
+																																			<name_plural>Subfamilies</name_plural>
+																																		</label>
+																																	</labels>
+																																	<items>
+																																		<item idno="subfamily" enabled="1" default="0">
+																																			<labels>
+																																				<label locale="en_AU" preferred="1">
+																																					<name_singular>Subfamily</name_singular>
+																																					<name_plural>Subfamilies</name_plural>
+																																				</label>
+																																			</labels>
+																																		</item>
+																																	</items>
+																																</item>
+																															</items>
+																														</item>
+																													</items>
+																												</item>
+																											</items>
+																										</item>
+																									</items>
+																								</item>
+																							</items>
+																						</item>
+																					</items>
+																				</item>
+																			</items>
+																		</item>
+
+																	</items>
+																</item>
+															</items>
+														</item>
+
+													</items>
+												</item>
+
+											</items>
+										</item>
+
+									</items>
+								</item>
+
+							</items>
+						</item>
+
+					</items>
         </item>
         <item idno="mineral" enabled="1" default="0">
           <labels>
@@ -1505,7 +1661,7 @@
         </item>
       </items>
     </list>
-    <list code="taxonomy" hierarchical="1" system="0" vocabulary="1"><labels><label locale="en_AU"><name>Taxon</name></label></labels><items><item idno="Animalia" enabled="1" default="0"><labels><label locale="en_AU" preferred="1"><name_singular>Animal</name_singular><name_plural>Animals</name_plural></label></labels></item></items></list>
+    <list code="taxonomy" hierarchical="1" system="0" vocabulary="1"><labels><label locale="en_AU"><name>Taxon</name></label></labels><items><item idno="Animalia" enabled="1" type="scientific_name" default="0"><labels><label locale="en_AU" preferred="1"><name_singular>Animal</name_singular><name_plural>Animals</name_plural></label></labels></item></items></list>
     <list code="place_hierarchies" hierarchical="1" system="0" vocabulary="0">
       <labels>
         <label locale="en_AU">

--- a/install/profiles/xml/wamcmis.xml
+++ b/install/profiles/xml/wamcmis.xml
@@ -32,162 +32,192 @@
               <name_plural>Taxon Names</name_plural>
             </label>
           </labels>
-					<items>
-						<item idno="kingdom" enabled="1" default="0">
-							<labels>
-								<label locale="en_AU" preferred="1">
-									<name_singular>Kingdom</name_singular>
-									<name_plural>Kingdoms</name_plural>
-								</label>
-							</labels>
-							<items>
-								<item idno="phylum" enabled="1" default="0">
-									<labels>
-										<label locale="en_AU" preferred="1">
-											<name_singular>phylum</name_singular>
-											<name_plural>phylum</name_plural>
-										</label>
-									</labels>
-									<items>
-										<item idno="subphylum" enabled="1" default="0">
-											<labels>
-												<label locale="en_AU" preferred="1">
-													<name_singular>Subphylum</name_singular>
-													<name_plural>Subphylum</name_plural>
-												</label>
-											</labels>
-											<items>
-												<item idno="class" enabled="1" default="0">
-													<labels>
-														<label locale="en_AU" preferred="1">
-															<name_singular>Class</name_singular>
-															<name_plural>Class</name_plural>
-														</label>
-													</labels>
-													<items>
-														<item idno="subclass" enabled="1" default="0">
-															<labels>
-																<label locale="en_AU" preferred="1">
-																	<name_singular>Subclass</name_singular>
-																	<name_plural>Subclasses</name_plural>
-																</label>
-															</labels>
-															<items>
-																<item idno="cohort" enabled="1" default="0">
-																	<labels>
-																		<label locale="en_AU" preferred="1">
-																			<name_singular>Cohort</name_singular>
-																			<name_plural>Cohorts</name_plural>
-																		</label>
-																	</labels>
-																	<items>
-																		<item idno="superorder" enabled="1" default="0">
-																			<labels>
-																				<label locale="en_AU" preferred="1">
-																					<name_singular>Superorder</name_singular>
-																					<name_plural>Superorders</name_plural>
-																				</label>
-																			</labels>
-																			<items>
-																				<item idno="order" enabled="1" default="0">
-																					<labels>
-																						<label locale="en_AU" preferred="1">
-																							<name_singular>Order</name_singular>
-																							<name_plural>Orders</name_plural>
-																						</label>
-																					</labels>
-																					<items>
-																						<item idno="infraorder" enabled="1" default="0">
-																							<labels>
-																								<label locale="en_AU" preferred="1">
-																									<name_singular>Infraorder</name_singular>
-																									<name_plural>Infraorders</name_plural>
-																								</label>
-																							</labels>
-																							<items>
-																								<item idno="suborder" enabled="1" default="0">
-																									<labels>
-																										<label locale="en_AU" preferred="1">
-																											<name_singular>Suborder</name_singular>
-																											<name_plural>Suborders</name_plural>
-																										</label>
-																									</labels>
-																									<items>
-																										<item idno="superfamily" enabled="1" default="0">
-																											<labels>
-																												<label locale="en_AU" preferred="1">
-																													<name_singular>Superfamily</name_singular>
-																													<name_plural>Superfamily</name_plural>
-																												</label>
-																											</labels>
-																											<items>
-																												<item idno="family" enabled="1" default="0">
-																													<labels>
-																														<label locale="en_AU" preferred="1">
-																															<name_singular>Family</name_singular>
-																															<name_plural>Families</name_plural>
-																														</label>
-																													</labels>
-																													<items>
-																														<item idno="subfamily" enabled="1" default="0">
-																															<labels>
-																																<label locale="en_AU" preferred="1">
-																																	<name_singular>Subfamily</name_singular>
-																																	<name_plural>Subfamilies</name_plural>
-																																</label>
-																															</labels>
-																															<items>
-																																<item idno="subfamily" enabled="1" default="0">
-																																	<labels>
-																																		<label locale="en_AU" preferred="1">
-																																			<name_singular>Subfamily</name_singular>
-																																			<name_plural>Subfamilies</name_plural>
-																																		</label>
-																																	</labels>
-																																	<items>
-																																		<item idno="subfamily" enabled="1" default="0">
-																																			<labels>
-																																				<label locale="en_AU" preferred="1">
-																																					<name_singular>Subfamily</name_singular>
-																																					<name_plural>Subfamilies</name_plural>
-																																				</label>
-																																			</labels>
-																																		</item>
-																																	</items>
-																																</item>
-																															</items>
-																														</item>
-																													</items>
-																												</item>
-																											</items>
-																										</item>
-																									</items>
-																								</item>
-																							</items>
-																						</item>
-																					</items>
-																				</item>
-																			</items>
-																		</item>
+          <items>
+            <item idno="kingdom" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>Kingdom</name_singular>
+                  <name_plural>Kingdoms</name_plural>
+                </label>
+              </labels>
+              <items>
+                <item idno="phylum" enabled="1" default="0">
+                  <labels>
+                    <label locale="en_AU" preferred="1">
+                      <name_singular>Phylum</name_singular>
+                      <name_plural>Phyla</name_plural>
+                    </label>
+                  </labels>
+                  <items>
+                    <item idno="subphylum" enabled="1" default="0">
+                      <labels>
+                        <label locale="en_AU" preferred="1">
+                          <name_singular>Subphylum</name_singular>
+                          <name_plural>Subphyla</name_plural>
+                        </label>
+                      </labels>
+                      <items>
+                        <item idno="class" enabled="1" default="0">
+                          <labels>
+                            <label locale="en_AU" preferred="1">
+                              <name_singular>Class</name_singular>
+                              <name_plural>Class</name_plural>
+                            </label>
+                          </labels>
+                          <items>
+                            <item idno="subclass" enabled="1" default="0">
+                              <labels>
+                                <label locale="en_AU" preferred="1">
+                                  <name_singular>Subclass</name_singular>
+                                  <name_plural>Subclasses</name_plural>
+                                </label>
+                              </labels>
+                              <items>
+                                <item idno="cohort" enabled="1" default="0">
+                                  <labels>
+                                    <label locale="en_AU" preferred="1">
+                                      <name_singular>Cohort</name_singular>
+                                      <name_plural>Cohorts</name_plural>
+                                    </label>
+                                  </labels>
+                                  <items>
+                                    <item idno="superorder" enabled="1" default="0">
+                                      <labels>
+                                        <label locale="en_AU" preferred="1">
+                                          <name_singular>Superorder</name_singular>
+                                          <name_plural>Superorders</name_plural>
+                                        </label>
+                                      </labels>
+                                      <items>
+                                        <item idno="order" enabled="1" default="0">
+                                          <labels>
+                                            <label locale="en_AU" preferred="1">
+                                              <name_singular>Order</name_singular>
+                                              <name_plural>Orders</name_plural>
+                                            </label>
+                                          </labels>
+                                          <items>
+                                            <item idno="infraorder" enabled="1" default="0">
+                                              <labels>
+                                                <label locale="en_AU" preferred="1">
+                                                  <name_singular>Infraorder</name_singular>
+                                                  <name_plural>Infraorders</name_plural>
+                                                </label>
+                                              </labels>
+                                              <items>
+                                                <item idno="suborder" enabled="1" default="0">
+                                                  <labels>
+                                                    <label locale="en_AU" preferred="1">
+                                                      <name_singular>Suborder</name_singular>
+                                                      <name_plural>Suborders</name_plural>
+                                                    </label>
+                                                  </labels>
+                                                  <items>
+                                                    <item idno="superfamily" enabled="1" default="0">
+                                                      <labels>
+                                                        <label locale="en_AU" preferred="1">
+                                                          <name_singular>Superfamily</name_singular>
+                                                          <name_plural>Superfamily</name_plural>
+                                                        </label>
+                                                      </labels>
+                                                      <items>
+                                                        <item idno="family" enabled="1" default="0">
+                                                          <labels>
+                                                            <label locale="en_AU" preferred="1">
+                                                              <name_singular>Family</name_singular>
+                                                              <name_plural>Families</name_plural>
+                                                            </label>
+                                                          </labels>
+                                                          <items>
+                                                            <item idno="subfamily" enabled="1" default="0">
+                                                              <labels>
+                                                                <label locale="en_AU" preferred="1">
+                                                                  <name_singular>Subfamily</name_singular>
+                                                                  <name_plural>Subfamilies</name_plural>
+                                                                </label>
+                                                              </labels>
+                                                              <items>
+                                                                <item idno="tribe" enabled="1" default="0">
+                                                                  <labels>
+                                                                    <label locale="en_AU" preferred="1">
+                                                                      <name_singular>Tribe</name_singular>
+                                                                      <name_plural>Tribe</name_plural>
+                                                                    </label>
+                                                                  </labels>
+                                                                  <items>
+                                                                    <item idno="genus" enabled="1" default="0">
+                                                                      <labels>
+                                                                        <label locale="en_AU" preferred="1">
+                                                                          <name_singular>Genus</name_singular>
+                                                                          <name_plural>Genera</name_plural>
+                                                                        </label>
+                                                                      </labels>
+                                                                      <items>
+                                                                        <item idno="subgenus" enabled="1" default="0">
+                                                                          <labels>
+                                                                            <label locale="en_AU" preferred="1">
+                                                                              <name_singular>Subgenus</name_singular>
+                                                                              <name_plural>Subgenera</name_plural>
+                                                                            </label>
+                                                                          </labels>
+                                                                          <items>
+                                                                            <item idno="species" enabled="1" default="0">
+                                                                              <labels>
+                                                                                <label locale="en_AU" preferred="1">
+                                                                                  <name_singular>Species</name_singular>
+                                                                                  <name_plural>Species</name_plural>
+                                                                                </label>
+                                                                              </labels>
+                                                                              <items>
+                                                                                <item idno="subspecies" enabled="1" default="0">
+                                                                                  <labels>
+                                                                                    <label locale="en_AU" preferred="1">
+                                                                                      <name_singular>Subspecies</name_singular>
+                                                                                      <name_plural>Subspecies</name_plural>
+                                                                                    </label>
+                                                                                  </labels>
+                                                                                </item>
+                                                                              </items>
+                                                                            </item>
+                                                                          </items>
+                                                                        </item>
+                                                                      </items>
+                                                                    </item>
+                                                                  </items>
+                                                                </item>
+                                                              </items>
+                                                            </item>
+                                                          </items>
+                                                        </item>
+                                                      </items>
+                                                    </item>
+                                                  </items>
+                                                </item>
+                                              </items>
+                                            </item>
+                                          </items>
+                                        </item>
+                                      </items>
+                                    </item>
 
-																	</items>
-																</item>
-															</items>
-														</item>
+                                  </items>
+                                </item>
+                              </items>
+                            </item>
 
-													</items>
-												</item>
+                          </items>
+                        </item>
 
-											</items>
-										</item>
+                      </items>
+                    </item>
 
-									</items>
-								</item>
+                  </items>
+                </item>
 
-							</items>
-						</item>
+              </items>
+            </item>
 
-					</items>
+          </items>
         </item>
         <item idno="mineral" enabled="1" default="0">
           <labels>
@@ -21671,6 +21701,24 @@ Example: "Quercus alba". For discussion see http://code.google.com/p/darwincore/
                 <setting name="description" locale="en_AU">You can enter details about the identification of this record. Ensure that you have the first item in the list is the current identification of the object.</setting>
                 <setting name="restrict_to_relationship_types">identification</setting>
                 <setting name="restrict_to_types">scientific_name</setting>
+                <setting name="restrict_to_types">kingdom</setting>
+                <setting name="restrict_to_types">phylum</setting>
+                <setting name="restrict_to_types">subphylum</setting>
+                <setting name="restrict_to_types">class</setting>
+                <setting name="restrict_to_types">subclass</setting>
+                <setting name="restrict_to_types">cohort</setting>
+                <setting name="restrict_to_types">superorder</setting>
+                <setting name="restrict_to_types">order</setting>
+                <setting name="restrict_to_types">infraorder</setting>
+                <setting name="restrict_to_types">suborder</setting>
+                <setting name="restrict_to_types">superfamily</setting>
+                <setting name="restrict_to_types">family</setting>
+                <setting name="restrict_to_types">subfamily</setting>
+                <setting name="restrict_to_types">tribe</setting>
+                <setting name="restrict_to_types">genus</setting>
+                <setting name="restrict_to_types">subgenus</setting>
+                <setting name="restrict_to_types">species</setting>
+                <setting name="restrict_to_types">subspecies</setting>
                 <setting name="list_format">bubbles</setting>
                 <setting name="sortDirection">ASC</setting>
                 <setting name="colorFirstItem">a7e8d5</setting>

--- a/install/profiles/xml/wamcmis.xml
+++ b/install/profiles/xml/wamcmis.xml
@@ -1252,14 +1252,6 @@
             </label>
           </labels>
         </item>
-        <item idno="identification" enabled="1" default="0">
-          <labels>
-            <label locale="en_AU" preferred="1">
-              <name_singular>Identification</name_singular>
-              <name_plural>Identifications</name_plural>
-            </label>
-          </labels>
-        </item>
         <item idno="anthropology_register" enabled="1" default="0">
           <labels>
             <label locale="en_AU" preferred="1">
@@ -10387,14 +10379,6 @@
                 </label>
               </labels>
             </item>
-            <item idno="crop_gut" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>crop;gut</name_singular>
-                  <name_plural>crop;gut</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="spleen" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
@@ -10408,14 +10392,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>heart</name_singular>
                   <name_plural>heart</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="liver_heart" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>liver;heart</name_singular>
-                  <name_plural>liver;heart</name_plural>
                 </label>
               </labels>
             </item>
@@ -10491,14 +10467,6 @@
                 </label>
               </labels>
             </item>
-            <item idno="right_kidney_" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>right kidney;</name_singular>
-                  <name_plural>right kidney;</name_plural>
-                </label>
-              </labels>
-            </item>
             <item idno="right_adrenal" enabled="1" default="0">
               <labels>
                 <label locale="en_AU" preferred="1">
@@ -10568,14 +10536,6 @@
                 <label locale="en_AU" preferred="1">
                   <name_singular>prostate</name_singular>
                   <name_plural>prostate</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="_0" enabled="1" default="0" value=".0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>.0</name_singular>
-                  <name_plural>.0</name_plural>
                 </label>
               </labels>
             </item>
@@ -14305,9 +14265,10 @@
             <setting name="canBeUsedInDisplay">1</setting>
             <setting name="listWidth">40</setting>
             <setting name="listHeight">200px</setting>
-            <setting name="requireValue">1</setting>
+            <setting name="requireValue">0</setting>
             <setting name="render">select</setting>
             <setting name="maxColumns">3</setting>
+            <setting name="nullOptionText">Not set</setting>
           </settings>
         </metadataElement>
         <metadataElement code="preparationCount" datatype="Numeric">
@@ -15347,15 +15308,6 @@ Examples: "1 m", "3 ft"</description>
       </settings>
       <typeRestrictions>
         <restriction>
-          <table>ca_occurrences</table>
-          <type>identification</type>
-          <settings>
-            <setting name="minAttributesPerRow">0</setting>
-            <setting name="maxAttributesPerRow">1</setting>
-            <setting name="minimumAttributeBundlesToDisplay">1</setting>
-          </settings>
-        </restriction>
-        <restriction>
           <table>ca_objects_x_vocabulary_terms</table>
           <type/>
           <includeSubtypes>1</includeSubtypes>
@@ -15378,15 +15330,6 @@ Examples: "1 m", "3 ft"</description>
         <setting name="fieldWidth">70</setting>
       </settings>
       <typeRestrictions>
-        <restriction>
-          <table>ca_occurrences</table>
-          <type>identification</type>
-          <settings>
-            <setting name="minAttributesPerRow">0</setting>
-            <setting name="maxAttributesPerRow">1</setting>
-            <setting name="minimumAttributeBundlesToDisplay">1</setting>
-          </settings>
-        </restriction>
         <restriction>
           <table>ca_objects_x_vocabulary_terms</table>
           <type/>
@@ -15414,15 +15357,6 @@ http://palaeontology.palass-pubs.org/pdf/Vol%2031/Pages%20223-227.pdf2011.</desc
         <setting name="maxColumns">6</setting>
       </settings>
       <typeRestrictions>
-        <restriction>
-          <table>ca_occurrences</table>
-          <type>identification</type>
-          <settings>
-            <setting name="minAttributesPerRow">0</setting>
-            <setting name="maxAttributesPerRow">6</setting>
-            <setting name="minimumAttributeBundlesToDisplay">1</setting>
-          </settings>
-        </restriction>
         <restriction>
           <table>ca_objects_x_vocabulary_terms</table>
           <type/>
@@ -15472,16 +15406,6 @@ http://palaeontology.palass-pubs.org/pdf/Vol%2031/Pages%20223-227.pdf2011.</desc
         </metadataElement>
       </elements>
       <typeRestrictions>
-        <restriction>
-          <table>ca_occurrences</table>
-          <type>identification</type>
-          <includeSubtypes>1</includeSubtypes>
-          <settings>
-            <setting name="minAttributesPerRow">0</setting>
-            <setting name="maxAttributesPerRow">1</setting>
-            <setting name="minimumAttributeBundlesToDisplay">1</setting>
-          </settings>
-        </restriction>
         <restriction>
           <table>ca_objects_x_vocabulary_terms</table>
           <type/>
@@ -15652,31 +15576,6 @@ http://palaeontology.palass-pubs.org/pdf/Vol%2031/Pages%20223-227.pdf2011.</desc
         </restriction>
       </typeRestrictions>
     </metadataElement>
-    <metadataElement code="scientificName" datatype="List" list="taxonomy">
-      <labels>
-        <label locale="en_AU">
-          <name>Scientific Name</name>
-          <description>The full scientific name, with authorship and date information if known. When forming part of an Identification, this should be the name in lowest level taxonomic rank that can be determined. This term should not contain identification qualifications, which should instead be supplied in the IdentificationQualifier term.</description>
-        </label>
-      </labels>
-      <settings>
-        <setting name="doesNotTakeLocale">0</setting>
-        <setting name="displayTemplate">Scientific Name: &lt;em&gt;scientificName&lt;/em&gt;</setting>
-        <setting name="requireValue">1</setting>
-        <setting name="render">horiz_hierbrowser_with_search</setting>
-      </settings>
-      <typeRestrictions>
-        <restriction>
-          <table>ca_occurrences</table>
-          <type>identification</type>
-          <settings>
-            <setting name="minAttributesPerRow">1</setting>
-            <setting name="maxAttributesPerRow">1</setting>
-            <setting name="minimumAttributeBundlesToDisplay">1</setting>
-          </settings>
-        </restriction>
-      </typeRestrictions>
-    </metadataElement>
     <metadataElement code="idVerificationStatus" datatype="List" list="identificationVerificationStatus">
       <labels>
         <label locale="en_AU">
@@ -15689,15 +15588,6 @@ http://palaeontology.palass-pubs.org/pdf/Vol%2031/Pages%20223-227.pdf2011.</desc
         <setting name="displayTemplate">Identification Verification Status: ^idVerificationStatus</setting>
       </settings>
       <typeRestrictions>
-        <restriction>
-          <table>ca_occurrences</table>
-          <type>identification</type>
-          <settings>
-            <setting name="minAttributesPerRow">0</setting>
-            <setting name="maxAttributesPerRow">1</setting>
-            <setting name="minimumAttributeBundlesToDisplay">1</setting>
-          </settings>
-        </restriction>
         <restriction>
           <table>ca_objects_x_vocabulary_terms</table>
           <type/>
@@ -15722,15 +15612,6 @@ http://palaeontology.palass-pubs.org/pdf/Vol%2031/Pages%20223-227.pdf2011.</desc
         <setting name="render">yes_no_checkboxes</setting>
       </settings>
       <typeRestrictions>
-        <restriction>
-          <table>ca_occurrences</table>
-          <type>identification</type>
-          <settings>
-            <setting name="minAttributesPerRow">1</setting>
-            <setting name="maxAttributesPerRow">1</setting>
-            <setting name="minimumAttributeBundlesToDisplay">1</setting>
-          </settings>
-        </restriction>
         <restriction>
           <table>ca_objects_x_vocabulary_terms</table>
           <type/>
@@ -18765,7 +18646,6 @@ Example: "Quercus alba". For discussion see http://code.google.com/p/darwincore/
         </label>
       </labels>
       <settings>
-        <setting name="requireValue">1</setting>
         <setting name="render">yes_no_checkboxes</setting>
       </settings>
       <typeRestrictions>
@@ -19875,6 +19755,10 @@ Example: "Quercus alba". For discussion see http://code.google.com/p/darwincore/
           <name>List item editor</name>
         </label>
       </labels>
+      <typeRestrictions>
+        <restriction type="concept"/>
+        <restriction type="mineral"/>
+      </typeRestrictions>
       <screens>
         <screen idno="basic" default="1">
           <labels>
@@ -19999,7 +19883,11 @@ Example: "Quercus alba". For discussion see http://code.google.com/p/darwincore/
               <name>Related Objects</name>
             </label>
           </labels>
-          <bundlePlacements/>
+          <bundlePlacements>
+            <placement code="ca_objects1">
+              <bundle>ca_objects</bundle>
+            </placement>
+          </bundlePlacements>
         </screen>
       </screens>
     </userInterface>
@@ -20413,8 +20301,6 @@ Example: "Quercus alba". For discussion see http://code.google.com/p/darwincore/
       </labels>
       <typeRestrictions>
         <restriction type="DarwinCore"/>
-        <restriction type="arachnid_myriapod"/>
-        <restriction type="tz"/>
       </typeRestrictions>
       <screens>
         <screen idno="record_level" default="1">
@@ -22011,24 +21897,6 @@ Lent to: &lt;unit relativeTo="ca_loans"&gt;&#13;
       </labels>
       <typeRestrictions>
         <restriction type="scientific_name"/>
-        <restriction type="class"/>
-        <restriction type="cohort"/>
-        <restriction type="family"/>
-        <restriction type="infraorder"/>
-        <restriction type="kingdom"/>
-        <restriction type="order"/>
-        <restriction type="phylum"/>
-        <restriction type="species"/>
-        <restriction type="subclass"/>
-        <restriction type="subfamily"/>
-        <restriction type="genus"/>
-        <restriction type="subgenus"/>
-        <restriction type="suborder"/>
-        <restriction type="subphylum"/>
-        <restriction type="subspecies"/>
-        <restriction type="superfamily"/>
-        <restriction type="superorder"/>
-        <restriction type="tribe"/>
       </typeRestrictions>
       <userAccess>
         <permission user="administrator" access="edit"/>
@@ -22136,6 +22004,21 @@ e.g. "Malacostraca", "Canis lupus".</setting>
               <settings>
                 <setting name="readonly"/>
               </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="related_objects" default="0">
+          <labels>
+            <label locale="en_AU">
+              <name>Related Objects</name>
+            </label>
+          </labels>
+          <typeRestrictions>
+            <restriction type="scientific_name"/>
+          </typeRestrictions>
+          <bundlePlacements>
+            <placement code="ca_objects1">
+              <bundle>ca_objects</bundle>
             </placement>
           </bundlePlacements>
         </screen>
@@ -23010,6 +22893,9 @@ Loaned to: &lt;unit relativeTo="ca_loans"&gt;&#13;
               <name>Media</name>
             </label>
           </labels>
+          <typeRestrictions>
+            <restriction type="anthropology"/>
+          </typeRestrictions>
           <bundlePlacements>
             <placement code="ca_object_representations1">
               <bundle>ca_object_representations</bundle>
@@ -23017,12 +22903,18 @@ Loaned to: &lt;unit relativeTo="ca_loans"&gt;&#13;
                 <setting name="list_format">bubbles</setting>
                 <setting name="sortDirection">ASC</setting>
                 <setting name="display_template">^ca_object_representations.preferred_labels</setting>
+                <setting name="readonly"/>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow"/>
+                <setting name="maxRelationshipsPerRow"/>
               </settings>
             </placement>
             <placement code="ca_attribute_external_link2">
               <bundle>ca_attribute_external_link</bundle>
               <settings>
                 <setting name="sortDirection">ASC</setting>
+                <setting name="readonly"/>
               </settings>
             </placement>
           </bundlePlacements>
@@ -23035,8 +22927,12 @@ Loaned to: &lt;unit relativeTo="ca_loans"&gt;&#13;
           </labels>
           <typeRestrictions>
             <restriction type="anthropology"/>
-            <restriction type="DublinCore"/>
-            <restriction type="DarwinCore"/>
+            <restriction type=""/>
+            <restriction type=""/>
+            <restriction type=""/>
+            <restriction type=""/>
+            <restriction type=""/>
+            <restriction type=""/>
           </typeRestrictions>
           <bundlePlacements>
             <placement code="item_status_id1">
@@ -23992,7 +23888,7 @@ Loaned to: &lt;unit relativeTo="ca_loans"&gt;&#13;
                 <setting name="restrict_to_types">family</setting>
                 <setting name="restrict_to_types">subfamily</setting>
                 <setting name="restrict_to_types">tribe</setting>
-								<setting name="restrict_to_types">genus</setting>
+                <setting name="restrict_to_types">genus</setting>
                 <setting name="restrict_to_types">subgenus</setting>
                 <setting name="restrict_to_types">species</setting>
                 <setting name="restrict_to_types">subspecies</setting>
@@ -24960,7 +24856,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
               <typename_reverse>is identification of</typename_reverse>
             </label>
           </labels>
-          <subTypeRight>identification</subTypeRight>
+          <subTypeRight/>
         </type>
         <type code="object_resource" default="0">
           <labels>
@@ -25198,7 +25094,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
               <typename_reverse>was identified by</typename_reverse>
             </label>
           </labels>
-          <subTypeRight>identification</subTypeRight>
+          <subTypeRight/>
         </type>
         <type code="entity_register" default="0">
           <labels>
@@ -25416,7 +25312,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
             </label>
           </labels>
           <subTypeLeft/>
-          <subTypeRight>identification</subTypeRight>
+          <subTypeRight/>
         </type>
       </types>
     </relationshipTable>
@@ -26045,14 +25941,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_locationRemarks" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_pointRadiusSpatialFit" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_earliestEonOrLowestEonothem" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_dateIdentified" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_identificationRemarks" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_identificationQualifier" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_typeStatus" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_georeference" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_scientificName" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_idVerificationStatus" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_etAl" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_measurementOrFact" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_minimumDepthInMeters" access="edit"/>
@@ -26328,7 +26217,6 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" type="conservation" access="edit"/>
         <permission table="ca_occurrences" type="conservation_job" access="edit"/>
         <permission table="ca_occurrences" type="exhibition" access="edit"/>
-        <permission table="ca_occurrences" type="identification" access="edit"/>
         <permission table="ca_occurrences" type="anthropology_register" access="edit"/>
         <permission table="ca_occurrences" type="resource" access="edit"/>
         <permission table="ca_occurrences" type="Root node for occurrence_types" access="none"/>
@@ -26705,14 +26593,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_locationRemarks" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_pointRadiusSpatialFit" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_earliestEonOrLowestEonothem" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_dateIdentified" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_identificationRemarks" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_identificationQualifier" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_typeStatus" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_georeference" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_scientificName" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_idVerificationStatus" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_etAl" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_measurementOrFact" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_minimumDepthInMeters" access="edit"/>
@@ -26991,7 +26872,6 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" type="conservation" access="read"/>
         <permission table="ca_occurrences" type="conservation_job" access="read"/>
         <permission table="ca_occurrences" type="exhibition" access="read"/>
-        <permission table="ca_occurrences" type="identification" access="none"/>
         <permission table="ca_occurrences" type="anthropology_register" access="read"/>
         <permission table="ca_occurrences" type="resource" access="edit"/>
         <permission table="ca_occurrences" type="Root node for occurrence_types" access="none"/>
@@ -27412,14 +27292,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_locationRemarks" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_pointRadiusSpatialFit" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_earliestEonOrLowestEonothem" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_dateIdentified" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_identificationRemarks" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_identificationQualifier" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_typeStatus" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_georeference" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_scientificName" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_idVerificationStatus" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_etAl" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_measurementOrFact" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_minimumDepthInMeters" access="edit"/>
@@ -27698,7 +27571,6 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" type="conservation" access="read"/>
         <permission table="ca_occurrences" type="conservation_job" access="read"/>
         <permission table="ca_occurrences" type="exhibition" access="read"/>
-        <permission table="ca_occurrences" type="identification" access="none"/>
         <permission table="ca_occurrences" type="anthropology_register" access="read"/>
         <permission table="ca_occurrences" type="resource" access="edit"/>
         <permission table="ca_occurrences" type="Root node for occurrence_types" access="none"/>
@@ -28119,7 +27991,6 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_dateIdentified" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcModified" access="none"/>
@@ -28132,7 +28003,6 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_earliestEonOrLowestEonothem" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_establishmentMeans" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_etAl" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_eventDate" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_eventRemarks" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_eventTime" access="none"/>
@@ -28141,9 +28011,6 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_habitat" access="none"/>
         <permission table="ca_occurrences" bundle="hierarchy_location" access="none"/>
         <permission table="ca_occurrences" bundle="hierarchy_navigation" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_idVerificationStatus" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_identificationQualifier" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_identificationRemarks" access="none"/>
         <permission table="ca_occurrences" bundle="idno" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_informationWithheld" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_institutionCode" access="none"/>
@@ -28180,11 +28047,9 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_rft_volume" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_samplingEffort" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_samplingProtocol" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_scientificName" access="none"/>
         <permission table="ca_occurrences" bundle="source_id" access="none"/>
         <permission table="ca_occurrences" bundle="status" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_substrate" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_typeStatus" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_verbatimDepth" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_verbatimElevation" access="none"/>
         <permission table="ca_collections" bundle="access" access="read"/>
@@ -28521,7 +28386,6 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" type="conservation" access="edit"/>
         <permission table="ca_occurrences" type="conservation_job" access="none"/>
         <permission table="ca_occurrences" type="exhibition" access="edit"/>
-        <permission table="ca_occurrences" type="identification" access="none"/>
         <permission table="ca_occurrences" type="map" access="edit"/>
         <permission table="ca_occurrences" type="anthropology_register" access="edit"/>
         <permission table="ca_occurrences" type="resource" access="edit"/>
@@ -28713,8 +28577,6 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
             <setting name="hierarchy_order">ASC</setting>
             <setting name="hierarchy_limit">0</setting>
             <setting name="hierarchical_delimiter"> ➔ </setting>
-            <setting name="restrict_to_relationship_types"/>
-            <setting name="restrict_to_types"/>
             <setting name="show_hierarchy">0</setting>
           </settings>
         </placement>

--- a/install/profiles/xml/wamcmis.xml
+++ b/install/profiles/xml/wamcmis.xml
@@ -177,8 +177,8 @@
                                                             </label>
                                                             </labels>
                                                             </item>
-                                                            </items>
-                                                            </item>
+          </items>
+        </item>
                                                             </items>
                                                             </item>
                                                             </items>
@@ -1686,7 +1686,7 @@
         </item>
       </items>
     </list>
-    <list code="taxonomy" hierarchical="1" system="0" vocabulary="1"><labels><label locale="en_AU"><name>Taxon</name></label></labels><items><item idno="Animalia" enabled="1" type="scientific_name" default="0"><labels><label locale="en_AU" preferred="1"><name_singular>Animal</name_singular><name_plural>Animals</name_plural></label></labels></item></items></list>
+    <list code="taxonomy" hierarchical="1" system="0" vocabulary="1"><labels><label locale="en_AU"><name>Taxon</name></label></labels><items><item idno="Animalia" enabled="1" type="kingdom" default="0"><labels><label locale="en_AU" preferred="1"><name_singular>Animal</name_singular><name_plural>Animals</name_plural></label></labels></item></items></list>
     <list code="place_hierarchies" hierarchical="1" system="0" vocabulary="0">
       <labels>
         <label locale="en_AU">

--- a/install/profiles/xml/wamcmis.xml
+++ b/install/profiles/xml/wamcmis.xml
@@ -145,14 +145,14 @@
                                                             </label>
                                                             </labels>
                                                             <items>
-                                                                    <item idno="genus" enabled="1" default="0">
-                                                                      <labels>
-                                                                        <label locale="en_AU" preferred="1">
-                                                                          <name_singular>Genus</name_singular>
-                                                                          <name_plural>Genera</name_plural>
-                                                                        </label>
-                                                                      </labels>
-                                                                      <items>
+                                                            <item idno="genus" enabled="1" default="0">
+                                                            <labels>
+                                                            <label locale="en_AU" preferred="1">
+                                                            <name_singular>Genus</name_singular>
+                                                            <name_plural>Genera</name_plural>
+                                                            </label>
+                                                            </labels>
+                                                            <items>
                                                             <item idno="subgenus" enabled="1" default="0">
                                                             <labels>
                                                             <label locale="en_AU" preferred="1">
@@ -177,8 +177,10 @@
                                                             </label>
                                                             </labels>
                                                             </item>
-          </items>
-        </item>
+                                                            </items>
+                                                            </item>
+                                                            </items>
+                                                            </item>
                                                             </items>
                                                             </item>
                                                             </items>
@@ -209,9 +211,6 @@
                 </item>
               </items>
             </item>
-          </items>
-        </item>
-
           </items>
         </item>
         <item idno="mineral" enabled="1" default="0">
@@ -1686,7 +1685,7 @@
         </item>
       </items>
     </list>
-    <list code="taxonomy" hierarchical="1" system="0" vocabulary="1"><labels><label locale="en_AU"><name>Taxon</name></label></labels><items><item idno="Animalia" enabled="1" type="kingdom" default="0"><labels><label locale="en_AU" preferred="1"><name_singular>Animal</name_singular><name_plural>Animals</name_plural></label></labels></item></items></list>
+    <list code="taxonomy" hierarchical="1" system="0" vocabulary="1"><labels><label locale="en_AU"><name>Taxon</name></label></labels><items><item idno="Animalia" enabled="1" default="0" type="kingdom"><labels><label locale="en_AU" preferred="1"><name_singular>Animal</name_singular><name_plural>Animals</name_plural></label></labels></item></items></list>
     <list code="place_hierarchies" hierarchical="1" system="0" vocabulary="0">
       <labels>
         <label locale="en_AU">
@@ -10777,7 +10776,7 @@
         </item>
       </items>
     </list>
-    <list code="eps_taxonomy" hierarchical="1" system="0" vocabulary="1"><labels><label locale="en_AU"><name>EPS Taxonomy</name></label></labels><items><item idno="eps_animalia" enabled="1" default="0"><labels><label locale="en_AU" preferred="1"><name_singular>Animal</name_singular><name_plural>Animals</name_plural></label></labels></item></items></list>
+    <list code="eps_taxonomy" hierarchical="1" system="0" vocabulary="1"><labels><label locale="en_AU"><name>EPS Taxonomy</name></label></labels><items><item idno="eps_animalia" enabled="1" default="0" type="scientific_name"><labels><label locale="en_AU" preferred="1"><name_singular>Animal</name_singular><name_plural>Animals</name_plural></label></labels></item></items></list>
     <list code="loan_status_types" hierarchical="0" system="0" vocabulary="0" defaultSort="1">
       <labels>
         <label locale="en_AU">
@@ -22016,16 +22015,15 @@ Lent to: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <restriction type="cohort"/>
         <restriction type="family"/>
         <restriction type="infraorder"/>
-				<restriction type="suborder"/>
         <restriction type="kingdom"/>
         <restriction type="order"/>
         <restriction type="phylum"/>
         <restriction type="species"/>
         <restriction type="subclass"/>
         <restriction type="subfamily"/>
-				<restriction type="genus"/>
+        <restriction type="genus"/>
         <restriction type="subgenus"/>
-        <restriction type="infraorder"/>
+        <restriction type="suborder"/>
         <restriction type="subphylum"/>
         <restriction type="subspecies"/>
         <restriction type="superfamily"/>
@@ -23086,6 +23084,9 @@ Loaned to: &lt;unit relativeTo="ca_loans"&gt;&#13;
             </placement>
             <placement code="ca_sets8">
               <bundle>ca_sets</bundle>
+              <settings>
+                <setting name="readonly"/>
+              </settings>
             </placement>
           </bundlePlacements>
         </screen>
@@ -25208,15 +25209,6 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
           </labels>
           <subTypeRight>anthropology_register</subTypeRight>
         </type>
-          <type code="dcCreator" default="0">
-            <labels>
-              <label locale="en_AU">
-                <typename>created</typename>
-                <typename_reverse>created by</typename_reverse>
-              </label>
-            </labels>
-            <subTypeRight>resource</subTypeRight>
-          </type>
         <type code="individual_request_cons" default="0">
           <labels>
             <label locale="en_AU">
@@ -25256,6 +25248,15 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
           </labels>
           <subTypeLeft>org</subTypeLeft>
           <subTypeRight>conservation_analysis</subTypeRight>
+        </type>
+        <type code="dcCreator" default="0">
+          <labels>
+            <label locale="en_AU">
+              <typename>created</typename>
+              <typename_reverse>created by</typename_reverse>
+            </label>
+          </labels>
+          <subTypeRight>resource</subTypeRight>
         </type>
         <type code="entity_resource" default="0">
           <labels>
@@ -28727,8 +28728,6 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
             <setting name="hierarchy_order">ASC</setting>
             <setting name="hierarchy_limit">0</setting>
             <setting name="hierarchical_delimiter"> ➔ </setting>
-            <setting name="restrict_to_relationship_types"/>
-            <setting name="restrict_to_types"/>
             <setting name="show_hierarchy">0</setting>
           </settings>
         </placement>
@@ -28914,24 +28913,25 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
             <setting name="label" locale="en_AU">Determined Scientific Name</setting>
             <setting name="format"/>
             <setting name="restrict_to_relationship_types">identification</setting>
-            <setting name="restrict_to_types">228</setting>
-            <setting name="restrict_to_types">82119</setting>
-            <setting name="restrict_to_types">82120</setting>
-            <setting name="restrict_to_types">82121</setting>
-            <setting name="restrict_to_types">82122</setting>
-            <setting name="restrict_to_types">82123</setting>
-            <setting name="restrict_to_types">82124</setting>
-            <setting name="restrict_to_types">82125</setting>
-            <setting name="restrict_to_types">82126</setting>
-            <setting name="restrict_to_types">82127</setting>
-            <setting name="restrict_to_types">82128</setting>
-            <setting name="restrict_to_types">82129</setting>
-            <setting name="restrict_to_types">82130</setting>
-            <setting name="restrict_to_types">82131</setting>
-            <setting name="restrict_to_types">82132</setting>
-            <setting name="restrict_to_types">82133</setting>
-            <setting name="restrict_to_types">82134</setting>
-            <setting name="restrict_to_types">82135</setting>
+            <setting name="restrict_to_types">scientific_name</setting>
+            <setting name="restrict_to_types">kingdom</setting>
+            <setting name="restrict_to_types">phylum</setting>
+            <setting name="restrict_to_types">subphylum</setting>
+            <setting name="restrict_to_types">class</setting>
+            <setting name="restrict_to_types">subclass</setting>
+            <setting name="restrict_to_types">cohort</setting>
+            <setting name="restrict_to_types">superorder</setting>
+            <setting name="restrict_to_types">order</setting>
+            <setting name="restrict_to_types">infraorder</setting>
+            <setting name="restrict_to_types">suborder</setting>
+            <setting name="restrict_to_types">superfamily</setting>
+            <setting name="restrict_to_types">family</setting>
+            <setting name="restrict_to_types">subfamily</setting>
+            <setting name="restrict_to_types">tribe</setting>
+            <setting name="restrict_to_types">genus</setting>
+            <setting name="restrict_to_types">subgenus</setting>
+            <setting name="restrict_to_types">species</setting>
+            <setting name="restrict_to_types">subspecies</setting>
             <setting name="delimiter"/>
             <setting name="show_hierarchy">1</setting>
             <setting name="remove_first_items">2</setting>
@@ -28958,8 +28958,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
             <setting name="hierarchy_limit">0</setting>
             <setting name="hierarchical_delimiter"> ➔ </setting>
             <setting name="makeEditorLink">0</setting>
-            <setting name="restrict_to_relationship_types"/>
-            <setting name="restrict_to_types">107</setting>
+            <setting name="restrict_to_types">internal</setting>
             <setting name="show_hierarchy">0</setting>
           </settings>
         </placement>
@@ -28973,8 +28972,8 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
 
 
 </setting>
-            <setting name="restrict_to_relationship_types">181</setting>
-            <setting name="restrict_to_types">241</setting>
+            <setting name="restrict_to_relationship_types">object_collecting_event</setting>
+            <setting name="restrict_to_types">collectingEvent</setting>
             <setting name="delimiter"/>
             <setting name="remove_first_items">0</setting>
             <setting name="hierarchy_order">ASC</setting>
@@ -29001,8 +29000,8 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
             <setting name="hierarchy_limit">0</setting>
             <setting name="hierarchical_delimiter"> ➔ </setting>
             <setting name="makeEditorLink">0</setting>
-            <setting name="restrict_to_relationship_types">182</setting>
-            <setting name="restrict_to_types">243</setting>
+            <setting name="restrict_to_relationship_types">object_identification</setting>
+            <setting name="restrict_to_types">identification</setting>
             <setting name="show_hierarchy">0</setting>
           </settings>
         </placement>
@@ -29033,8 +29032,6 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
             <setting name="hierarchy_order">ASC</setting>
             <setting name="hierarchy_limit">0</setting>
             <setting name="hierarchical_delimiter"> ➔ </setting>
-            <setting name="restrict_to_relationship_types"/>
-            <setting name="restrict_to_types"/>
           </settings>
         </placement>
         <placement code="ca_objects_acquisition_type_id">

--- a/themes/default/css/local.css
+++ b/themes/default/css/local.css
@@ -125,3 +125,16 @@ div.notification-warning-box {
 	text-align: center;
 	opacity: 1.0;
 }
+
+table.table-bordered{
+	border-spacing: 0;
+}
+table.table-bordered th,
+table.table-bordered td{
+	border: 1px solid #3f3d40;
+
+	padding: 0.5em;
+}
+div.field-label{
+	font-weight: bold;
+}


### PR DESCRIPTION
Being able to export data correctly and generate labels means that we have to have different types for different list items. We also need to fully implement https://github.com/kehh/providence/tree/restrictHierarchyToTypes for this to be fully working.

```
kehh    Creating taxon ranks in list item types 7b0f33d
kehh    Add remaining taxon ranks to list item types …    0e0b21b
kehh    Update to profile to support different list item types for different … …    bc9862f
kehh    Change type of 'Animalia' to 'kingdom'  b769284
kehh    Additional changes to support Scientific Names of different types …   63bb3da
kehh    Styling for display templates including ident    e1fd96e
kehh    WIP Add option for 'restrictHierarchyToTypes' …   9692ff9
```

Commits on Sep 02, 2014
    kehh    Update to installation profile …   8abba35
    kehh    Revert "WIP Add option for 'restrictHierarchyToTypes'" … f1e9cec
