### PR TITLE
Profile update 20140925

### DIFF
--- a/install/profiles/xml/wamcmis.xml
+++ b/install/profiles/xml/wamcmis.xml
@@ -12818,6 +12818,55 @@
         </item>
       </items>
     </list>
+    <list code="phone_types" hierarchical="0" system="1" vocabulary="0">
+      <labels>
+        <label locale="en_AU">
+          <name>Phone Types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="work" enabled="1" default="1">
+          <labels>
+            <label locale="en_AU" preferred="1">
+              <name_singular>Work</name_singular>
+              <name_plural>Work</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="mobile" enabled="1" default="0">
+          <labels>
+            <label locale="en_AU" preferred="1">
+              <name_singular>Mobile</name_singular>
+              <name_plural>Mobile</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="fax" enabled="1" default="0">
+          <labels>
+            <label locale="en_AU" preferred="1">
+              <name_singular>Fax</name_singular>
+              <name_plural>Faxes</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="other" enabled="1" default="0">
+          <labels>
+            <label locale="en_AU" preferred="1">
+              <name_singular>Other</name_singular>
+              <name_plural>Others</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="other_1" enabled="1" default="0">
+          <labels>
+            <label locale="en_AU" preferred="1">
+              <name_singular>Home</name_singular>
+              <name_plural>Home</name_plural>
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
   </lists>
   <elementSets>
     <metadataElement code="set_description" datatype="Text">
@@ -13703,7 +13752,7 @@
             <setting name="listWidth">40</setting>
             <setting name="listHeight">200px</setting>
             <setting name="doesNotTakeLocale">1</setting>
-            <setting name="requireValue">1</setting>
+            <setting name="requireValue">0</setting>
             <setting name="canBeUsedInSort">1</setting>
             <setting name="render">select</setting>
             <setting name="maxColumns">3</setting>
@@ -13793,27 +13842,7 @@
         </restriction>
         <restriction>
           <table>ca_objects</table>
-          <type>mineral_simpson</type>
-          <includeSubtypes>1</includeSubtypes>
-          <settings>
-            <setting name="minAttributesPerRow">0</setting>
-            <setting name="maxAttributesPerRow">1</setting>
-            <setting name="minimumAttributeBundlesToDisplay">1</setting>
-          </settings>
-        </restriction>
-        <restriction>
-          <table>ca_objects</table>
-          <type>mineral_mdc</type>
-          <includeSubtypes>1</includeSubtypes>
-          <settings>
-            <setting name="minAttributesPerRow">0</setting>
-            <setting name="maxAttributesPerRow">1</setting>
-            <setting name="minimumAttributeBundlesToDisplay">1</setting>
-          </settings>
-        </restriction>
-        <restriction>
-          <table>ca_objects</table>
-          <type>invertebrate_palaeontology</type>
+          <type>eps</type>
           <includeSubtypes>1</includeSubtypes>
           <settings>
             <setting name="minAttributesPerRow">0</setting>
@@ -13861,9 +13890,10 @@
         </label>
       </labels>
       <settings>
-        <setting name="fieldWidth">70</setting>
+        <setting name="fieldWidth">120</setting>
         <setting name="fieldHeight">4</setting>
         <setting name="doesNotTakeLocale">1</setting>
+        <setting name="usewysiwygeditor">1</setting>
       </settings>
       <typeRestrictions>
         <restriction>
@@ -13892,7 +13922,6 @@
         </restriction>
         <restriction>
           <table>ca_occurrences</table>
-          <type/>
           <settings>
             <setting name="minAttributesPerRow">1</setting>
             <setting name="maxAttributesPerRow">1</setting>
@@ -14077,12 +14106,34 @@
     <metadataElement code="telephone" datatype="Text">
       <labels>
         <label locale="en_AU">
-          <name>Telephone/fax</name>
+          <name>Telephone</name>
+          <description>Enter telephone contact details</description>
         </label>
       </labels>
       <settings>
         <setting name="fieldWidth">70</setting>
       </settings>
+      <elements>
+        <metadataElement code="phone_type" datatype="List" list="phone_types">
+          <labels>
+            <label locale="en_AU">
+              <name>Phone Type</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="doesNotTakeLocale">1</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="render">select</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+          </settings>
+        </metadataElement>
+      </elements>
       <typeRestrictions>
         <restriction>
           <table>ca_entities</table>
@@ -16653,6 +16704,7 @@ http://palaeontology.palass-pubs.org/pdf/Vol%2031/Pages%20223-227.pdf2011.</desc
             <setting name="maxColumns">3</setting>
             <setting name="canBeUsedInSearchForm">1</setting>
             <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="nullOptionText">Not set</setting>
           </settings>
         </metadataElement>
       </elements>
@@ -16669,6 +16721,16 @@ http://palaeontology.palass-pubs.org/pdf/Vol%2031/Pages%20223-227.pdf2011.</desc
         <restriction>
           <table>ca_objects</table>
           <type>tz</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_objects</table>
+          <type>eps</type>
           <includeSubtypes>1</includeSubtypes>
           <settings>
             <setting name="minAttributesPerRow">0</setting>
@@ -18489,7 +18551,7 @@ This is a legacy field for anthropology and will be excluded from the user inter
       <typeRestrictions>
         <restriction>
           <table>ca_occurrences</table>
-          <type>conservation</type>
+          <type>conservation_job</type>
           <settings>
             <setting name="minAttributesPerRow">0</setting>
             <setting name="maxAttributesPerRow">3</setting>
@@ -19472,6 +19534,16 @@ Examples: &lt;em&gt;James L. Patton&lt;/em&gt;, &lt;em&gt;Theodore Pappenfuss&lt
             <setting name="minimumAttributeBundlesToDisplay">1</setting>
           </settings>
         </restriction>
+        <restriction>
+          <table>ca_objects</table>
+          <type>eps</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
       </typeRestrictions>
     </metadataElement>
     <metadataElement code="quarantine" datatype="List" list="yesNo">
@@ -19762,8 +19834,6 @@ Example: "Quercus alba". For discussion see http://code.google.com/p/darwincore/
       </labels>
       <settings>
         <setting name="lineBreakAfterNumberOfElements">2</setting>
-        <setting name="canBeUsedInSearchForm">0</setting>
-        <setting name="canBeUsedInDisplay">0</setting>
       </settings>
       <elements>
         <metadataElement code="stratigraphy" datatype="List" list="geologic_time_scale">
@@ -19937,7 +20007,15 @@ Example: "Quercus alba". For discussion see http://code.google.com/p/darwincore/
         <restriction>
           <table>ca_objects</table>
           <type>vertebrate_palaeontology</type>
-          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_objects</table>
+          <type>invertebrate_palaeontology</type>
           <settings>
             <setting name="minAttributesPerRow">0</setting>
             <setting name="maxAttributesPerRow">1</setting>
@@ -20095,10 +20173,11 @@ Example: "Quercus alba". For discussion see http://code.google.com/p/darwincore/
       <labels>
         <label locale="en_AU">
           <name>Determination</name>
-          <description>Enter the determination of the object</description>
+          <description>This widget contains the determination and date of determination of the object.  You can add multiple determinations by pressing 'Add determination'.</description>
         </label>
       </labels>
       <settings>
+        <setting name="fieldWidth">60</setting>
         <setting name="suggestExistingValues">1</setting>
       </settings>
       <elements>
@@ -20134,6 +20213,15 @@ Example: "Quercus alba". For discussion see http://code.google.com/p/darwincore/
             <setting name="minAttributesPerRow">0</setting>
             <setting name="maxAttributesPerRow">255</setting>
             <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_objects</table>
+          <type>vertebrate_palaeontology</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">0</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
           </settings>
         </restriction>
       </typeRestrictions>
@@ -20216,7 +20304,8 @@ Example: "Quercus alba". For discussion see http://code.google.com/p/darwincore/
       <typeRestrictions>
         <restriction>
           <table>ca_objects</table>
-          <type>invertebrate_palaeontology</type>
+          <type>eps</type>
+          <includeSubtypes>1</includeSubtypes>
           <settings>
             <setting name="minAttributesPerRow">0</setting>
             <setting name="maxAttributesPerRow">255</setting>
@@ -20228,15 +20317,18 @@ Example: "Quercus alba". For discussion see http://code.google.com/p/darwincore/
     <metadataElement code="number_of_specimens" datatype="Numeric">
       <labels>
         <label locale="en_AU">
-          <name>Number of specimens</name>
-          <description>Enter the number of specimens. This field is similar to but not entirely compatible with DarwinCore individualCount field.</description>
+          <name>Number of objects</name>
+          <description>Enter the number of items in this 'specimen'.</description>
         </label>
       </labels>
+      <settings>
+        <setting name="fieldWidth">60</setting>
+      </settings>
       <elements>
         <metadataElement code="number_of_specimens_text" datatype="Text">
           <labels>
             <label locale="en_AU">
-              <name>Text value</name>
+              <name>Other information</name>
               <description>Additional field to capture information not captured by the integer field for number of specimens</description>
             </label>
           </labels>
@@ -20254,8 +20346,6 @@ Example: "Quercus alba". For discussion see http://code.google.com/p/darwincore/
             <setting name="default_text"/>
             <setting name="canBeUsedInSearchForm">1</setting>
             <setting name="canBeUsedInDisplay">1</setting>
-            <setting name="displayTemplate"/>
-            <setting name="displayDelimiter">,</setting>
             <setting name="isDependentValue">0</setting>
           </settings>
         </metadataElement>
@@ -20264,6 +20354,7 @@ Example: "Quercus alba". For discussion see http://code.google.com/p/darwincore/
         <restriction>
           <table>ca_objects</table>
           <type>eps</type>
+          <includeSubtypes>1</includeSubtypes>
           <settings>
             <setting name="minAttributesPerRow">0</setting>
             <setting name="maxAttributesPerRow">1</setting>
@@ -20285,7 +20376,7 @@ Example: "Quercus alba". For discussion see http://code.google.com/p/darwincore/
       <typeRestrictions>
         <restriction>
           <table>ca_objects</table>
-          <type>invertebrate_palaeontology</type>
+          <type>eps</type>
           <includeSubtypes>1</includeSubtypes>
           <settings>
             <setting name="minAttributesPerRow">0</setting>
@@ -20328,11 +20419,19 @@ Example: "Quercus alba". For discussion see http://code.google.com/p/darwincore/
         <restriction>
           <table>ca_objects</table>
           <type>invertebrate_palaeontology</type>
-          <includeSubtypes>1</includeSubtypes>
           <settings>
             <setting name="minAttributesPerRow">0</setting>
             <setting name="maxAttributesPerRow">1</setting>
             <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_objects</table>
+          <type>vertebrate_palaeontology</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">0</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
           </settings>
         </restriction>
       </typeRestrictions>
@@ -20882,6 +20981,26 @@ Display in stable environment  Temperature ??°C ± ?°C seasonally, ± ?°C d
           <settings>
             <setting name="minAttributesPerRow">0</setting>
             <setting name="maxAttributesPerRow">10</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="internal" datatype="List" list="yesNo">
+      <labels>
+        <label locale="en_AU">
+          <name>Internal Organisation</name>
+          <description>Specifies whether the organisation is internal to the museum.</description>
+        </label>
+      </labels>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_entities</table>
+          <type>org</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
             <setting name="minimumAttributeBundlesToDisplay">1</setting>
           </settings>
         </restriction>
@@ -21743,6 +21862,12 @@ Display in stable environment  Temperature ??°C ± ?°C seasonally, ± ?°C d
       </labels>
       <typeRestrictions>
         <restriction type="DarwinCore"/>
+        <restriction type=""/>
+        <restriction type=""/>
+        <restriction type=""/>
+        <restriction type=""/>
+        <restriction type=""/>
+        <restriction type=""/>
       </typeRestrictions>
       <screens>
         <screen idno="record_level" default="1">
@@ -21784,6 +21909,20 @@ Display in stable environment  Temperature ??°C ± ?°C seasonally, ± ?°C d
               <settings>
                 <setting name="readonly"/>
                 <setting name="sortDirection">ASC</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_sex9">
+              <bundle>ca_attribute_sex</bundle>
+              <settings>
+                <setting name="readonly"/>
+                <setting name="sortDirection">ASC</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_lifeStage10">
+              <bundle>ca_attribute_lifeStage</bundle>
+              <settings>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="readonly"/>
               </settings>
             </placement>
             <placement code="ca_attribute_accessionDate6">
@@ -21943,20 +22082,6 @@ Display in stable environment  Temperature ??°C ± ?°C seasonally, ± ?°C d
             </placement>
             <placement code="ca_attribute_multipleMounts14">
               <bundle>ca_attribute_multipleMounts</bundle>
-              <settings>
-                <setting name="sortDirection">ASC</setting>
-                <setting name="readonly"/>
-              </settings>
-            </placement>
-            <placement code="ca_attribute_sex9">
-              <bundle>ca_attribute_sex</bundle>
-              <settings>
-                <setting name="readonly"/>
-                <setting name="sortDirection">ASC</setting>
-              </settings>
-            </placement>
-            <placement code="ca_attribute_lifeStage10">
-              <bundle>ca_attribute_lifeStage</bundle>
               <settings>
                 <setting name="sortDirection">ASC</setting>
                 <setting name="readonly"/>
@@ -22204,39 +22329,56 @@ Lent to: &lt;unit relativeTo="ca_loans"&gt;&#13;
           <bundlePlacements>
             <placement code="idno1">
               <bundle>idno</bundle>
-              <settings/>
+              <settings>
+                <setting name="readonly"/>
+              </settings>
             </placement>
             <placement code="object_id2">
               <bundle>object_id</bundle>
-              <settings/>
+              <settings>
+                <setting name="readonly"/>
+              </settings>
             </placement>
             <placement code="source_id3">
               <bundle>source_id</bundle>
-              <settings/>
+              <settings>
+                <setting name="readonly"/>
+              </settings>
             </placement>
             <placement code="hierarchy_location4">
               <bundle>hierarchy_location</bundle>
               <settings>
                 <setting name="open_hierarchy">1</setting>
+                <setting name="readonly"/>
               </settings>
             </placement>
             <placement code="hierarchy_navigation5">
               <bundle>hierarchy_navigation</bundle>
               <settings>
                 <setting name="open_hierarchy">1</setting>
+                <setting name="readonly"/>
               </settings>
             </placement>
             <placement code="status6">
               <bundle>status</bundle>
-              <settings/>
+              <settings>
+                <setting name="readonly"/>
+              </settings>
             </placement>
             <placement code="acquisition_type_id7">
               <bundle>acquisition_type_id</bundle>
-              <settings/>
+              <settings>
+                <setting name="readonly"/>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_otherCatalogNumbe">
+              <bundle>ca_attribute_otherCatalogNumbers</bundle>
             </placement>
             <placement code="access8">
               <bundle>access</bundle>
-              <settings/>
+              <settings>
+                <setting name="readonly"/>
+              </settings>
             </placement>
           </bundlePlacements>
         </screen>
@@ -22296,6 +22438,21 @@ Lent to: &lt;unit relativeTo="ca_loans"&gt;&#13;
                 <setting name="maxRelationshipsPerRow"/>
               </settings>
             </placement>
+            <placement code="ca_entities2">
+              <bundle>ca_entities</bundle>
+              <settings>
+                <setting name="label" locale="en_AU">Collector</setting>
+                <setting name="readonly"/>
+                <setting name="restrict_to_relationship_types">discover</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="display_template">^ca_entities.preferred_labels</setting>
+                <setting name="minRelationshipsPerRow"/>
+                <setting name="maxRelationshipsPerRow"/>
+              </settings>
+            </placement>
             <placement code="ca_attribute_eventDate1">
               <bundle>ca_attribute_eventDate</bundle>
               <settings>
@@ -22323,6 +22480,9 @@ Lent to: &lt;unit relativeTo="ca_loans"&gt;&#13;
                 <setting name="readonly"/>
                 <setting name="sortDirection">ASC</setting>
               </settings>
+            </placement>
+            <placement code="ca_attribute_habitat7">
+              <bundle>ca_attribute_habitat</bundle>
             </placement>
             <placement code="ca_attribute_distanceFromLocal">
               <bundle>ca_attribute_distanceFromLocality</bundle>
@@ -22407,7 +22567,14 @@ Lent to: &lt;unit relativeTo="ca_loans"&gt;&#13;
               <bundle>ca_attribute_sex</bundle>
               <settings>
                 <setting name="sortDirection">ASC</setting>
+                <setting name="readonly"/>
               </settings>
+            </placement>
+            <placement code="ca_attribute_internal6">
+              <bundle>ca_attribute_internal</bundle>
+            </placement>
+            <placement code="ca_attribute_internal_notes7">
+              <bundle>ca_attribute_internal_notes</bundle>
             </placement>
             <placement code="ca_attribute_biography">
               <bundle>ca_attribute_biography</bundle>
@@ -22549,7 +22716,6 @@ Lent to: &lt;unit relativeTo="ca_loans"&gt;&#13;
       </typeRestrictions>
       <groupAccess>
         <permission group="admin" access="edit"/>
-        <permission group="cataloguer" access="read"/>
       </groupAccess>
       <screens>
         <screen idno="basic_occurrence" default="1">
@@ -23345,7 +23511,6 @@ Lent to: &lt;unit relativeTo="ca_loans"&gt;&#13;
       </userAccess>
       <groupAccess>
         <permission group="admin" access="read"/>
-        <permission group="cataloguer" access="read"/>
       </groupAccess>
       <screens>
         <screen idno="scientific_name_details" default="1">
@@ -23477,7 +23642,6 @@ e.g. "Malacostraca", "Canis lupus".</setting>
       </typeRestrictions>
       <groupAccess>
         <permission group="admin" access="edit"/>
-        <permission group="cataloguer" access="read"/>
       </groupAccess>
       <screens>
         <screen idno="basic_collecting_event" default="1">
@@ -23719,9 +23883,6 @@ e.g. "Malacostraca", "Canis lupus".</setting>
       <typeRestrictions>
         <restriction type="anthropology"/>
       </typeRestrictions>
-      <groupAccess>
-        <permission group="anthropology" access="read"/>
-      </groupAccess>
       <screens>
         <screen idno="anthropology_general" default="0">
           <labels>
@@ -24369,6 +24530,12 @@ Loaned to: &lt;unit relativeTo="ca_loans"&gt;&#13;
           </labels>
           <typeRestrictions>
             <restriction type="anthropology"/>
+            <restriction type=""/>
+            <restriction type=""/>
+            <restriction type=""/>
+            <restriction type=""/>
+            <restriction type=""/>
+            <restriction type=""/>
           </typeRestrictions>
           <bundlePlacements>
             <placement code="item_status_id1">
@@ -24433,9 +24600,6 @@ Loaned to: &lt;unit relativeTo="ca_loans"&gt;&#13;
       <userAccess>
         <permission user="administrator" access="edit"/>
       </userAccess>
-      <groupAccess>
-        <permission group="anthropology" access="read"/>
-      </groupAccess>
       <screens>
         <screen idno="basic" default="0">
           <labels>
@@ -24476,9 +24640,6 @@ Loaned to: &lt;unit relativeTo="ca_loans"&gt;&#13;
       <userAccess>
         <permission user="administrator" access="edit"/>
       </userAccess>
-      <groupAccess>
-        <permission group="conservators" access="read"/>
-      </groupAccess>
       <screens>
         <screen idno="job_details" default="1">
           <labels>
@@ -25037,9 +25198,6 @@ Loaned to: &lt;unit relativeTo="ca_loans"&gt;&#13;
       <userAccess>
         <permission user="administrator" access="edit"/>
       </userAccess>
-      <groupAccess>
-        <permission group="mineralogy" access="read"/>
-      </groupAccess>
       <screens>
         <screen idno="basic_minerals" default="1">
           <labels>
@@ -25258,10 +25416,6 @@ Loaned to: &lt;unit relativeTo="ca_loans"&gt;&#13;
       <userAccess>
         <permission user="administrator" access="edit"/>
       </userAccess>
-      <groupAccess>
-        <permission group="vertebrate_palaeo" access="read"/>
-        <permission group="invert_palaeo" access="read"/>
-      </groupAccess>
       <screens>
         <screen idno="eps_palaeo_basic" default="1">
           <labels>
@@ -25277,11 +25431,26 @@ Loaned to: &lt;unit relativeTo="ca_loans"&gt;&#13;
             <placement code="idno1">
               <bundle>idno</bundle>
               <settings>
+                <setting name="label" locale="en_AU">Specimen Identifier</setting>
+                <setting name="description" locale="en_AU">This is the unique identifier for the specimen.  It is a free text field with no validation.</setting>
                 <setting name="readonly"/>
               </settings>
             </placement>
             <placement code="ca_attribute_accessionDate2">
               <bundle>ca_attribute_accessionDate</bundle>
+              <settings>
+                <setting name="readonly"/>
+                <setting name="sortDirection">ASC</setting>
+              </settings>
+            </placement>
+            <placement code="acquisition_type_id3">
+              <bundle>acquisition_type_id</bundle>
+              <settings>
+                <setting name="readonly"/>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_number_of_specime">
+              <bundle>ca_attribute_number_of_specimens</bundle>
               <settings>
                 <setting name="readonly"/>
                 <setting name="sortDirection">ASC</setting>
@@ -25376,8 +25545,8 @@ Loaned to: &lt;unit relativeTo="ca_loans"&gt;&#13;
                 <setting name="restrictToTermsOnCollectionUseRelationshipType">116</setting>
               </settings>
             </placement>
-            <placement code="ca_attribute_number_of_specime">
-              <bundle>ca_attribute_number_of_specimens</bundle>
+            <placement code="ca_attribute_storageLocationNo">
+              <bundle>ca_attribute_storageLocationNotes</bundle>
               <settings>
                 <setting name="readonly"/>
                 <setting name="sortDirection">ASC</setting>
@@ -25449,13 +25618,8 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
                 <setting name="ca_storage_locations_displayTemplate">&lt;l&gt;^ca_storage_locations.hierarchy.preferred_labels%delimiter=_➔_&lt;/l&gt;</setting>
                 <setting name="showDeaccessionInformation"/>
                 <setting name="deaccession_color">#EEEEEE</setting>
-              </settings>
-            </placement>
-            <placement code="ca_attribute_storageLocationNo">
-              <bundle>ca_attribute_storageLocationNotes</bundle>
-              <settings>
-                <setting name="readonly"/>
-                <setting name="sortDirection">ASC</setting>
+                <setting name="ca_occurrences_conservation_report_dateElement">dcModified</setting>
+                <setting name="ca_occurrences_conservation_report_color">#EEEEEE</setting>
               </settings>
             </placement>
             <placement code="ca_entities9">
@@ -25464,6 +25628,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
                 <setting name="label" locale="en_AU">Collectors</setting>
                 <setting name="add_label" locale="en_AU">add collectors</setting>
                 <setting name="description" locale="en_AU">Record the details of the individuals responsible for collecting the object</setting>
+                <setting name="width">100%</setting>
                 <setting name="readonly"/>
                 <setting name="restrict_to_relationship_types">discover</setting>
                 <setting name="restrict_to_types">ind</setting>
@@ -25490,6 +25655,14 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
                 <setting name="sortDirection">ASC</setting>
               </settings>
             </placement>
+            <placement code="ca_attribute_lithostratigraphi">
+              <bundle>ca_attribute_lithostratigraphic_provenance</bundle>
+              <settings>
+                <setting name="width">70</setting>
+                <setting name="readonly"/>
+                <setting name="sortDirection">ASC</setting>
+              </settings>
+            </placement>
             <placement code="ca_attribute_GeologicalContext">
               <bundle>ca_attribute_GeologicalContext</bundle>
               <settings>
@@ -25497,9 +25670,10 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
                 <setting name="sortDirection">ASC</setting>
               </settings>
             </placement>
-            <placement code="ca_attribute_lithostratigraphi">
-              <bundle>ca_attribute_lithostratigraphic_provenance</bundle>
+            <placement code="ca_attribute_siteDetailsPalaeo">
+              <bundle>ca_attribute_siteDetailsPalaeontology</bundle>
               <settings>
+                <setting name="label" locale="en_AU">Site Details</setting>
                 <setting name="readonly"/>
                 <setting name="sortDirection">ASC</setting>
               </settings>
@@ -25507,8 +25681,35 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
             <placement code="ca_attribute_locality12">
               <bundle>ca_attribute_locality</bundle>
               <settings>
+                <setting name="description" locale="en_AU">This is for the description of the locality - please use the Named Localities widget below to contribute to the listing of Named Localities for the Museum if you can.</setting>
+                <setting name="width">40</setting>
                 <setting name="readonly"/>
                 <setting name="sortDirection">ASC</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_distanceFromLocal">
+              <bundle>ca_attribute_distanceFromLocality</bundle>
+              <settings>
+                <setting name="width">40</setting>
+                <setting name="readonly"/>
+                <setting name="sortDirection">ASC</setting>
+              </settings>
+            </placement>
+            <placement code="ca_places17">
+              <bundle>ca_places</bundle>
+              <settings>
+                <setting name="label" locale="en_AU">Named Localities</setting>
+                <setting name="description" locale="en_AU">If you have a named locality as the location, please use this form; it will ensure that we can have all named localities in one area for the Museum.</setting>
+                <setting name="readonly"/>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="display_template">^ca_places.preferred_labels</setting>
+                <setting name="minRelationshipsPerRow"/>
+                <setting name="maxRelationshipsPerRow"/>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
               </settings>
             </placement>
             <placement code="ca_attribute_georeference13">
@@ -25518,18 +25719,34 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
                 <setting name="sortDirection">ASC</setting>
               </settings>
             </placement>
-            <placement code="ca_attribute_siteDetailsPalaeo">
-              <bundle>ca_attribute_siteDetailsPalaeontology</bundle>
+            <placement code="ca_attribute_internal_notes11">
+              <bundle>ca_attribute_internal_notes</bundle>
               <settings>
+                <setting name="label" locale="en_AU">Notes</setting>
                 <setting name="readonly"/>
                 <setting name="sortDirection">ASC</setting>
               </settings>
             </placement>
-            <placement code="ca_attribute_internal_notes11">
-              <bundle>ca_attribute_internal_notes</bundle>
+          </bundlePlacements>
+        </screen>
+        <screen idno="screen_38_1" default="0">
+          <labels>
+            <label locale="en_AU">
+              <name>Media</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_object_representations1">
+              <bundle>ca_object_representations</bundle>
               <settings>
                 <setting name="readonly"/>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
                 <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="display_template">^ca_object_representations.preferred_labels</setting>
+                <setting name="minRelationshipsPerRow"/>
+                <setting name="maxRelationshipsPerRow"/>
               </settings>
             </placement>
           </bundlePlacements>
@@ -25549,6 +25766,12 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
       <userAccess>
         <permission user="administrator" access="edit"/>
       </userAccess>
+      <groupAccess>
+        <permission group="admin" access="edit"/>
+        <permission group="History_Catalogue" access="read"/>
+        <permission group="History_Curate" access="read"/>
+        <permission group="History_View" access="read"/>
+      </groupAccess>
       <screens>
         <screen idno="history_basic" default="1">
           <labels>
@@ -27025,6 +27248,16 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
           <subTypeLeft/>
           <subTypeRight/>
         </type>
+        <type code="copied_from" default="0">
+          <labels>
+            <label locale="en_AU">
+              <typename>copied from</typename>
+              <typename_reverse>copied to</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft>conservation_job</subTypeLeft>
+          <subTypeRight>conservation_job</subTypeRight>
+        </type>
       </types>
     </relationshipTable>
     <relationshipTable name="ca_occurrences_x_vocabulary_terms">
@@ -28173,1493 +28406,6 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_tour_stops" type="Root node for tour_stop_types" access="none"/>
       </typeLevelAccessControl>
     </role>
-    <role code="az_cataloguer">
-      <name>Aquatic Zoology Cataloguer</name>
-      <description>Gives access to the Aquatic Zoology cataloging capabilities.</description>
-      <actions>
-        <action>can_view_logs</action>
-        <action>can_quicksearch</action>
-        <action>can_set_preferences</action>
-        <action>can_create_adv_search_forms</action>
-        <action>can_edit_adv_search_forms</action>
-        <action>can_delete_adv_search_forms</action>
-        <action>can_use_adv_search_forms</action>
-        <action>can_create_ca_bundle_displays</action>
-        <action>can_edit_ca_bundle_displays</action>
-        <action>can_delete_ca_bundle_displays</action>
-        <action>can_use_ca_bundle_displays</action>
-        <action>can_duplicate_ca_bundle_displays</action>
-        <action>can_create_user_groups</action>
-        <action>can_create_sets</action>
-        <action>can_edit_sets</action>
-        <action>can_delete_own_sets</action>
-        <action>can_view_sets</action>
-        <action>can_duplicate_ca_sets</action>
-        <action>can_create_ca_objects</action>
-        <action>can_edit_ca_objects</action>
-        <action>can_delete_ca_objects</action>
-        <action>can_search_ca_objects</action>
-        <action>can_browse_ca_objects</action>
-        <action>can_download_ca_object_representations</action>
-        <action>can_duplicate_ca_objects</action>
-        <action>can_export_ca_objects</action>
-        <action>can_change_acl_ca_objects</action>
-        <action>can_batch_edit_ca_objects</action>
-        <action>can_create_ca_representation_annotations</action>
-        <action>can_edit_ca_representation_annotations</action>
-        <action>can_delete_ca_representation_annotations</action>
-        <action>can_search_ca_representation_annotations</action>
-        <action>can_browse_ca_representation_annotations</action>
-        <action>can_duplicate_ca_representation_annotations</action>
-        <action>can_create_ca_entities</action>
-        <action>can_edit_ca_entities</action>
-        <action>can_delete_ca_entities</action>
-        <action>can_search_ca_entities</action>
-        <action>can_browse_ca_entities</action>
-        <action>can_duplicate_ca_entities</action>
-        <action>can_export_ca_entities</action>
-        <action>can_quickadd_ca_entities</action>
-        <action>can_batch_edit_ca_entities</action>
-        <action>can_create_ca_places</action>
-        <action>can_edit_ca_places</action>
-        <action>can_delete_ca_places</action>
-        <action>can_search_ca_places</action>
-        <action>can_browse_ca_places</action>
-        <action>can_duplicate_ca_places</action>
-        <action>can_export_ca_places</action>
-        <action>can_quickadd_ca_places</action>
-        <action>can_batch_edit_ca_places</action>
-        <action>can_create_ca_occurrences</action>
-        <action>can_edit_ca_occurrences</action>
-        <action>can_delete_ca_occurrences</action>
-        <action>can_search_ca_occurrences</action>
-        <action>can_browse_ca_occurrences</action>
-        <action>can_quickadd_ca_occurrences</action>
-        <action>can_search_ca_collections</action>
-        <action>can_browse_ca_collections</action>
-        <action>can_create_ca_storage_locations</action>
-        <action>can_edit_ca_storage_locations</action>
-        <action>can_delete_ca_storage_locations</action>
-        <action>can_search_ca_storage_locations</action>
-        <action>can_browse_ca_storage_locations</action>
-        <action>can_quickadd_ca_storage_locations</action>
-        <action>can_create_ca_loans</action>
-        <action>can_edit_ca_loans</action>
-        <action>can_delete_ca_loans</action>
-        <action>can_search_ca_loans</action>
-        <action>can_browse_ca_loans</action>
-        <action>can_duplicate_ca_loans</action>
-        <action>can_export_ca_loans</action>
-        <action>can_quickadd_ca_loans</action>
-        <action>can_create_ca_movements</action>
-        <action>can_edit_ca_movements</action>
-        <action>can_delete_ca_movements</action>
-        <action>can_search_ca_movements</action>
-        <action>can_browse_ca_movements</action>
-        <action>can_duplicate_ca_movements</action>
-        <action>can_export_ca_movements</action>
-        <action>can_quickadd_ca_movements</action>
-        <action>can_create_ca_lists</action>
-        <action>can_edit_ca_lists</action>
-        <action>can_delete_ca_lists</action>
-        <action>can_export_ca_list_items</action>
-        <action>can_download_media</action>
-        <action>can_use_statistics_viewer_plugin</action>
-        <action>can_use_adv_search_form_widget</action>
-        <action>can_use_counts_widget</action>
-        <action>can_use_last_logins_widget</action>
-        <action>can_use_recent_changes_widget</action>
-        <action>can_use_recent_comment_widget</action>
-        <action>can_use_recent_tag_widget</action>
-        <action>can_use_recently_created_widget_ca_objects</action>
-        <action>can_use_recently_created_widget_ca_entities</action>
-        <action>can_use_recently_created_widget_ca_places</action>
-        <action>can_use_recently_created_widget_ca_occurrences</action>
-        <action>can_use_recently_created_widget_ca_sets</action>
-        <action>can_use_recently_created_widget_ca_collections</action>
-        <action>can_use_recently_created_widget_ca_object_representations</action>
-        <action>can_use_recently_created_widget_ca_object_lots</action>
-        <action>can_use_records_by_status_widget_ca_objects</action>
-        <action>can_use_records_by_status_widget_ca_entities</action>
-        <action>can_use_records_by_status_widget_ca_places</action>
-        <action>can_use_records_by_status_widget_ca_occurrences</action>
-        <action>can_use_records_by_status_widget_ca_sets</action>
-        <action>can_use_records_by_status_widget_ca_collections</action>
-        <action>can_use_records_by_status_widget_ca_object_representations</action>
-        <action>can_use_records_by_status_widget_ca_object_lots</action>
-        <action>can_use_track_processing_widget</action>
-      </actions>
-      <bundleLevelAccessControl>
-        <permission table="ca_objects" bundle="preferred_labels" access="edit"/>
-        <permission table="ca_objects" bundle="nonpreferred_labels" access="edit"/>
-        <permission table="ca_objects" bundle="object_id" access="edit"/>
-        <permission table="ca_objects" bundle="locale_id" access="edit"/>
-        <permission table="ca_objects" bundle="source_id" access="edit"/>
-        <permission table="ca_objects" bundle="idno" access="edit"/>
-        <permission table="ca_objects" bundle="item_status_id" access="edit"/>
-        <permission table="ca_objects" bundle="acquisition_type_id" access="edit"/>
-        <permission table="ca_objects" bundle="extent" access="edit"/>
-        <permission table="ca_objects" bundle="extent_units" access="edit"/>
-        <permission table="ca_objects" bundle="access" access="edit"/>
-        <permission table="ca_objects" bundle="status" access="edit"/>
-        <permission table="ca_objects" bundle="rank" access="edit"/>
-        <permission table="ca_objects" bundle="acl_inherit_from_ca_collections" access="edit"/>
-        <permission table="ca_objects" bundle="acl_inherit_from_parent" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_description" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_description_source" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_external_link" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_geonames" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_internal_notes" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_dcType" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_dcModified" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_dcLanguage" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_dcRights" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_dcBibCitation" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_institutionID" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_institutionCode" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_ownerInstitutionCode" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_informationWithheld" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_dataGeneralizations" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_dynamicProperties" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_occurrenceDetails" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_occurrenceRemarks" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_individualCount" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_sex" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_lifeStage" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_reproductiveCondition" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_behavior" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_establishmentMeans" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_occurrenceStatus" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_preparations" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_disposition" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_otherCatalogNumbers" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_associatedSequences" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_country" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_verbatimElevation" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_minimumElevationInMeters" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_maximumElevationInMeters" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_minDistAboveSurface" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_maxDistAboveSurface" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_pointRadiusSpatialFit" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_earliestEonOrLowestEonothem" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_relationship_info" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_accessionDate" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_dctermscreated" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_dcSubject" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_SizeOrDuration" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_technique" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_colour" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_anthropologyMaterialTypes" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_audit" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_eventDate" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_eventRemarks" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_sightedDetails" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_languageName" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_collector_flag" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_siteDetails" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_tradition" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_languageAffiliation" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_supportingDocumentation" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_objectDetails" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_objectPublished" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_documentation" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_objectClassification" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_donation_date" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_francisStStore" access="edit"/>
-        <permission table="ca_objects" bundle="ca_object_representations" access="edit"/>
-        <permission table="ca_objects" bundle="ca_objects" access="edit"/>
-        <permission table="ca_objects" bundle="ca_entities" access="edit"/>
-        <permission table="ca_objects" bundle="ca_places" access="edit"/>
-        <permission table="ca_objects" bundle="ca_occurrences" access="edit"/>
-        <permission table="ca_objects" bundle="ca_collections" access="edit"/>
-        <permission table="ca_objects" bundle="ca_storage_locations" access="edit"/>
-        <permission table="ca_objects" bundle="ca_loans" access="edit"/>
-        <permission table="ca_objects" bundle="ca_movements" access="edit"/>
-        <permission table="ca_objects" bundle="ca_tour_stops" access="edit"/>
-        <permission table="ca_objects" bundle="ca_object_lots" access="edit"/>
-        <permission table="ca_objects" bundle="ca_list_items" access="edit"/>
-        <permission table="ca_objects" bundle="ca_sets" access="edit"/>
-        <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
-        <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
-        <permission table="ca_objects" bundle="ca_commerce_order_history" access="edit"/>
-        <permission table="ca_entities" bundle="preferred_labels" access="edit"/>
-        <permission table="ca_entities" bundle="nonpreferred_labels" access="edit"/>
-        <permission table="ca_entities" bundle="entity_id" access="edit"/>
-        <permission table="ca_entities" bundle="locale_id" access="edit"/>
-        <permission table="ca_entities" bundle="source_id" access="edit"/>
-        <permission table="ca_entities" bundle="idno" access="edit"/>
-        <permission table="ca_entities" bundle="lifespan" access="edit"/>
-        <permission table="ca_entities" bundle="access" access="edit"/>
-        <permission table="ca_entities" bundle="status" access="edit"/>
-        <permission table="ca_entities" bundle="rank" access="edit"/>
-        <permission table="ca_entities" bundle="ca_attribute_external_link" access="edit"/>
-        <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
-        <permission table="ca_entities" bundle="ca_attribute_biography" access="edit"/>
-        <permission table="ca_entities" bundle="ca_attribute_address" access="edit"/>
-        <permission table="ca_entities" bundle="ca_attribute_telephone" access="edit"/>
-        <permission table="ca_entities" bundle="ca_attribute_url" access="edit"/>
-        <permission table="ca_entities" bundle="ca_attribute_email" access="edit"/>
-        <permission table="ca_entities" bundle="ca_attribute_sex" access="edit"/>
-        <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
-        <permission table="ca_entities" bundle="ca_object_representations" access="edit"/>
-        <permission table="ca_entities" bundle="ca_entities" access="edit"/>
-        <permission table="ca_entities" bundle="ca_places" access="edit"/>
-        <permission table="ca_entities" bundle="ca_objects" access="edit"/>
-        <permission table="ca_entities" bundle="ca_occurrences" access="edit"/>
-        <permission table="ca_entities" bundle="ca_collections" access="edit"/>
-        <permission table="ca_entities" bundle="ca_object_lots" access="edit"/>
-        <permission table="ca_entities" bundle="ca_loans" access="edit"/>
-        <permission table="ca_entities" bundle="ca_movements" access="edit"/>
-        <permission table="ca_entities" bundle="ca_storage_locations" access="edit"/>
-        <permission table="ca_entities" bundle="ca_tour_stops" access="edit"/>
-        <permission table="ca_entities" bundle="ca_list_items" access="edit"/>
-        <permission table="ca_entities" bundle="ca_sets" access="edit"/>
-        <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
-        <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
-        <permission table="ca_places" bundle="preferred_labels" access="edit"/>
-        <permission table="ca_places" bundle="nonpreferred_labels" access="edit"/>
-        <permission table="ca_places" bundle="place_id" access="edit"/>
-        <permission table="ca_places" bundle="parent_id" access="edit"/>
-        <permission table="ca_places" bundle="locale_id" access="edit"/>
-        <permission table="ca_places" bundle="source_id" access="edit"/>
-        <permission table="ca_places" bundle="idno" access="edit"/>
-        <permission table="ca_places" bundle="lifespan" access="edit"/>
-        <permission table="ca_places" bundle="access" access="edit"/>
-        <permission table="ca_places" bundle="status" access="edit"/>
-        <permission table="ca_places" bundle="rank" access="edit"/>
-        <permission table="ca_places" bundle="ca_attribute_description" access="edit"/>
-        <permission table="ca_places" bundle="ca_attribute_description_source" access="edit"/>
-        <permission table="ca_places" bundle="ca_attribute_external_link" access="edit"/>
-        <permission table="ca_places" bundle="ca_attribute_geonames" access="edit"/>
-        <permission table="ca_places" bundle="ca_attribute_internal_notes" access="edit"/>
-        <permission table="ca_places" bundle="ca_attribute_dcType" access="edit"/>
-        <permission table="ca_places" bundle="ca_attribute_dcModified" access="edit"/>
-        <permission table="ca_places" bundle="ca_attribute_dcLanguage" access="edit"/>
-        <permission table="ca_places" bundle="ca_attribute_dcRights" access="edit"/>
-        <permission table="ca_places" bundle="ca_attribute_dcBibCitation" access="edit"/>
-        <permission table="ca_places" bundle="ca_attribute_institutionID" access="edit"/>
-        <permission table="ca_places" bundle="ca_attribute_institutionCode" access="edit"/>
-        <permission table="ca_places" bundle="ca_attribute_ownerInstitutionCode" access="edit"/>
-        <permission table="ca_places" bundle="ca_attribute_informationWithheld" access="edit"/>
-        <permission table="ca_places" bundle="ca_attribute_dataGeneralizations" access="edit"/>
-        <permission table="ca_places" bundle="ca_attribute_dynamicProperties" access="edit"/>
-        <permission table="ca_places" bundle="ca_attribute_occurrenceDetails" access="edit"/>
-        <permission table="ca_places" bundle="ca_attribute_occurrenceRemarks" access="edit"/>
-        <permission table="ca_places" bundle="ca_attribute_country" access="edit"/>
-        <permission table="ca_places" bundle="ca_attribute_verbatimElevation" access="edit"/>
-        <permission table="ca_places" bundle="ca_attribute_minimumElevationInMeters" access="edit"/>
-        <permission table="ca_places" bundle="ca_attribute_maximumElevationInMeters" access="edit"/>
-        <permission table="ca_places" bundle="ca_attribute_minDistAboveSurface" access="edit"/>
-        <permission table="ca_places" bundle="ca_attribute_maxDistAboveSurface" access="edit"/>
-        <permission table="ca_places" bundle="ca_attribute_pointRadiusSpatialFit" access="edit"/>
-        <permission table="ca_places" bundle="ca_attribute_georeference" access="edit"/>
-        <permission table="ca_places" bundle="ca_attribute_languageAffiliation" access="edit"/>
-        <permission table="ca_places" bundle="ca_object_representations" access="edit"/>
-        <permission table="ca_places" bundle="ca_entities" access="edit"/>
-        <permission table="ca_places" bundle="ca_objects" access="edit"/>
-        <permission table="ca_places" bundle="ca_object_lots" access="edit"/>
-        <permission table="ca_places" bundle="ca_places" access="edit"/>
-        <permission table="ca_places" bundle="ca_collections" access="edit"/>
-        <permission table="ca_places" bundle="ca_occurrences" access="edit"/>
-        <permission table="ca_places" bundle="ca_storage_locations" access="edit"/>
-        <permission table="ca_places" bundle="ca_loans" access="edit"/>
-        <permission table="ca_places" bundle="ca_movements" access="edit"/>
-        <permission table="ca_places" bundle="ca_tour_stops" access="edit"/>
-        <permission table="ca_places" bundle="ca_list_items" access="edit"/>
-        <permission table="ca_places" bundle="ca_sets" access="edit"/>
-        <permission table="ca_places" bundle="hierarchy_navigation" access="edit"/>
-        <permission table="ca_places" bundle="hierarchy_location" access="edit"/>
-        <permission table="ca_occurrences" bundle="preferred_labels" access="edit"/>
-        <permission table="ca_occurrences" bundle="nonpreferred_labels" access="edit"/>
-        <permission table="ca_occurrences" bundle="occurrence_id" access="edit"/>
-        <permission table="ca_occurrences" bundle="parent_id" access="edit"/>
-        <permission table="ca_occurrences" bundle="locale_id" access="edit"/>
-        <permission table="ca_occurrences" bundle="idno" access="edit"/>
-        <permission table="ca_occurrences" bundle="source_id" access="edit"/>
-        <permission table="ca_occurrences" bundle="access" access="edit"/>
-        <permission table="ca_occurrences" bundle="status" access="edit"/>
-        <permission table="ca_occurrences" bundle="rank" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_external_link" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_internal_notes" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_dcModified" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_dcRights" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_institutionID" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_institutionCode" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_ownerInstitutionCode" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_informationWithheld" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_occurrenceDetails" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_occurrenceRemarks" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_recordNumber" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_reproductiveCondition" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_behavior" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_establishmentMeans" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_occurrenceStatus" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_otherCatalogNumbers" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_associatedSequences" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_samplingProtocol" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_samplingEffort" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_eventDate" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_eventTime" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_habitat" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_eventRemarks" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_verbatimElevation" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_minimumElevationInMeters" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_maximumElevationInMeters" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_verbatimDepth" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_maximumDepthInMeters" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_minDistAboveSurface" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_maxDistAboveSurface" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_locationRemarks" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_pointRadiusSpatialFit" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_earliestEonOrLowestEonothem" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_georeference" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_measurementOrFact" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_minimumDepthInMeters" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_substrate" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_rft_pages" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_noPages" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_media" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_resourceDateRange" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_registerRecordData" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_registerClassification" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_rft_volume" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_ConservationSlide" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_BWNeg" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_CNeg" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_CDRom" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_Archive" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_ArtefactList" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_AssignmentDates" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_AssignmentTimeMaterials" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_AnalysisRequested" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_AnalysisReceived" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_ExcelReference" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_object_representations" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_entities" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_objects" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_object_lots" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_occurrences" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_collections" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_places" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_storage_locations" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_loans" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_movements" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_tour_stops" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_list_items" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_sets" access="edit"/>
-        <permission table="ca_occurrences" bundle="hierarchy_navigation" access="edit"/>
-        <permission table="ca_occurrences" bundle="hierarchy_location" access="edit"/>
-        <permission table="ca_collections" bundle="preferred_labels" access="edit"/>
-        <permission table="ca_collections" bundle="nonpreferred_labels" access="edit"/>
-        <permission table="ca_collections" bundle="collection_id" access="edit"/>
-        <permission table="ca_collections" bundle="locale_id" access="edit"/>
-        <permission table="ca_collections" bundle="idno" access="edit"/>
-        <permission table="ca_collections" bundle="source_id" access="edit"/>
-        <permission table="ca_collections" bundle="access" access="edit"/>
-        <permission table="ca_collections" bundle="status" access="edit"/>
-        <permission table="ca_collections" bundle="rank" access="edit"/>
-        <permission table="ca_collections" bundle="acl_inherit_from_parent" access="edit"/>
-        <permission table="ca_collections" bundle="ca_attribute_description" access="edit"/>
-        <permission table="ca_collections" bundle="ca_attribute_description_source" access="edit"/>
-        <permission table="ca_collections" bundle="ca_attribute_external_link" access="edit"/>
-        <permission table="ca_collections" bundle="ca_attribute_internal_notes" access="edit"/>
-        <permission table="ca_collections" bundle="ca_attribute_dcType" access="edit"/>
-        <permission table="ca_collections" bundle="ca_attribute_dcModified" access="edit"/>
-        <permission table="ca_collections" bundle="ca_attribute_dcLanguage" access="edit"/>
-        <permission table="ca_collections" bundle="ca_attribute_dcRights" access="edit"/>
-        <permission table="ca_collections" bundle="ca_attribute_dcBibCitation" access="edit"/>
-        <permission table="ca_collections" bundle="ca_attribute_institutionID" access="edit"/>
-        <permission table="ca_collections" bundle="ca_attribute_institutionCode" access="edit"/>
-        <permission table="ca_collections" bundle="ca_attribute_ownerInstitutionCode" access="edit"/>
-        <permission table="ca_collections" bundle="ca_attribute_informationWithheld" access="edit"/>
-        <permission table="ca_collections" bundle="ca_attribute_dataGeneralizations" access="edit"/>
-        <permission table="ca_collections" bundle="ca_attribute_dynamicProperties" access="edit"/>
-        <permission table="ca_collections" bundle="ca_attribute_occurrenceDetails" access="edit"/>
-        <permission table="ca_collections" bundle="ca_attribute_occurrenceRemarks" access="edit"/>
-        <permission table="ca_collections" bundle="ca_attribute_country" access="edit"/>
-        <permission table="ca_collections" bundle="ca_attribute_verbatimElevation" access="edit"/>
-        <permission table="ca_collections" bundle="ca_attribute_minimumElevationInMeters" access="edit"/>
-        <permission table="ca_collections" bundle="ca_attribute_maximumElevationInMeters" access="edit"/>
-        <permission table="ca_collections" bundle="ca_attribute_minDistAboveSurface" access="edit"/>
-        <permission table="ca_collections" bundle="ca_attribute_maxDistAboveSurface" access="edit"/>
-        <permission table="ca_collections" bundle="ca_attribute_pointRadiusSpatialFit" access="edit"/>
-        <permission table="ca_collections" bundle="ca_attribute_earliestEonOrLowestEonothem" access="edit"/>
-        <permission table="ca_collections" bundle="ca_object_representations" access="edit"/>
-        <permission table="ca_collections" bundle="ca_entities" access="edit"/>
-        <permission table="ca_collections" bundle="ca_objects" access="edit"/>
-        <permission table="ca_collections" bundle="ca_places" access="edit"/>
-        <permission table="ca_collections" bundle="ca_collections" access="edit"/>
-        <permission table="ca_collections" bundle="ca_occurrences" access="edit"/>
-        <permission table="ca_collections" bundle="ca_object_lots" access="edit"/>
-        <permission table="ca_collections" bundle="ca_storage_locations" access="edit"/>
-        <permission table="ca_collections" bundle="ca_list_items" access="edit"/>
-        <permission table="ca_collections" bundle="ca_sets" access="edit"/>
-        <permission table="ca_collections" bundle="ca_loans" access="edit"/>
-        <permission table="ca_collections" bundle="ca_movements" access="edit"/>
-        <permission table="ca_collections" bundle="ca_tour_stops" access="edit"/>
-        <permission table="ca_collections" bundle="hierarchy_navigation" access="edit"/>
-        <permission table="ca_collections" bundle="hierarchy_location" access="edit"/>
-        <permission table="ca_object_lots" bundle="preferred_labels" access="edit"/>
-        <permission table="ca_object_lots" bundle="nonpreferred_labels" access="edit"/>
-        <permission table="ca_object_lots" bundle="lot_id" access="edit"/>
-        <permission table="ca_object_lots" bundle="lot_status_id" access="edit"/>
-        <permission table="ca_object_lots" bundle="idno_stub" access="edit"/>
-        <permission table="ca_object_lots" bundle="extent" access="edit"/>
-        <permission table="ca_object_lots" bundle="extent_units" access="edit"/>
-        <permission table="ca_object_lots" bundle="access" access="edit"/>
-        <permission table="ca_object_lots" bundle="status" access="edit"/>
-        <permission table="ca_object_lots" bundle="rank" access="edit"/>
-        <permission table="ca_object_lots" bundle="ca_attribute_description" access="edit"/>
-        <permission table="ca_object_lots" bundle="ca_attribute_lot_notes" access="edit"/>
-        <permission table="ca_object_lots" bundle="ca_attribute_dcType" access="edit"/>
-        <permission table="ca_object_lots" bundle="ca_attribute_dcModified" access="edit"/>
-        <permission table="ca_object_lots" bundle="ca_attribute_dcLanguage" access="edit"/>
-        <permission table="ca_object_lots" bundle="ca_attribute_dcRights" access="edit"/>
-        <permission table="ca_object_lots" bundle="ca_attribute_dcBibCitation" access="edit"/>
-        <permission table="ca_object_lots" bundle="ca_attribute_institutionID" access="edit"/>
-        <permission table="ca_object_lots" bundle="ca_attribute_institutionCode" access="edit"/>
-        <permission table="ca_object_lots" bundle="ca_attribute_ownerInstitutionCode" access="edit"/>
-        <permission table="ca_object_lots" bundle="ca_attribute_informationWithheld" access="edit"/>
-        <permission table="ca_object_lots" bundle="ca_attribute_dataGeneralizations" access="edit"/>
-        <permission table="ca_object_lots" bundle="ca_attribute_dynamicProperties" access="edit"/>
-        <permission table="ca_object_lots" bundle="ca_object_representations" access="edit"/>
-        <permission table="ca_object_lots" bundle="ca_entities" access="edit"/>
-        <permission table="ca_object_lots" bundle="ca_places" access="edit"/>
-        <permission table="ca_object_lots" bundle="ca_occurrences" access="edit"/>
-        <permission table="ca_object_lots" bundle="ca_collections" access="edit"/>
-        <permission table="ca_object_lots" bundle="ca_storage_locations" access="edit"/>
-        <permission table="ca_object_lots" bundle="ca_loans" access="edit"/>
-        <permission table="ca_object_lots" bundle="ca_movements" access="edit"/>
-        <permission table="ca_object_lots" bundle="ca_object_lots" access="edit"/>
-        <permission table="ca_object_lots" bundle="ca_list_items" access="edit"/>
-        <permission table="ca_object_lots" bundle="ca_sets" access="edit"/>
-        <permission table="ca_object_lots" bundle="ca_objects" access="edit"/>
-        <permission table="ca_loans" bundle="preferred_labels" access="edit"/>
-        <permission table="ca_loans" bundle="nonpreferred_labels" access="edit"/>
-        <permission table="ca_loans" bundle="loan_id" access="edit"/>
-        <permission table="ca_loans" bundle="idno" access="edit"/>
-        <permission table="ca_loans" bundle="status" access="edit"/>
-        <permission table="ca_loans" bundle="rank" access="edit"/>
-        <permission table="ca_loans" bundle="ca_attribute_loan_authorization_date" access="edit"/>
-        <permission table="ca_loans" bundle="ca_attribute_loan_in_date" access="edit"/>
-        <permission table="ca_loans" bundle="ca_attribute_loan_out_date" access="edit"/>
-        <permission table="ca_loans" bundle="ca_attribute_loan_return_date" access="edit"/>
-        <permission table="ca_loans" bundle="ca_attribute_loan_renewal_date" access="edit"/>
-        <permission table="ca_loans" bundle="ca_attribute_loan_conditions" access="edit"/>
-        <permission table="ca_loans" bundle="ca_attribute_loan_note" access="edit"/>
-        <permission table="ca_loans" bundle="ca_attribute_loan_purpose" access="edit"/>
-        <permission table="ca_loans" bundle="ca_object_representations" access="edit"/>
-        <permission table="ca_loans" bundle="ca_objects" access="edit"/>
-        <permission table="ca_loans" bundle="ca_object_lots" access="edit"/>
-        <permission table="ca_loans" bundle="ca_entities" access="edit"/>
-        <permission table="ca_loans" bundle="ca_places" access="edit"/>
-        <permission table="ca_loans" bundle="ca_occurrences" access="edit"/>
-        <permission table="ca_loans" bundle="ca_collections" access="edit"/>
-        <permission table="ca_loans" bundle="ca_loans" access="edit"/>
-        <permission table="ca_loans" bundle="ca_movements" access="edit"/>
-        <permission table="ca_loans" bundle="ca_storage_locations" access="edit"/>
-        <permission table="ca_loans" bundle="ca_list_items" access="edit"/>
-        <permission table="ca_movements" bundle="preferred_labels" access="edit"/>
-        <permission table="ca_movements" bundle="nonpreferred_labels" access="edit"/>
-        <permission table="ca_movements" bundle="movement_id" access="edit"/>
-        <permission table="ca_movements" bundle="idno" access="edit"/>
-        <permission table="ca_movements" bundle="status" access="edit"/>
-        <permission table="ca_movements" bundle="rank" access="edit"/>
-        <permission table="ca_movements" bundle="ca_attribute_movement_method" access="edit"/>
-        <permission table="ca_movements" bundle="ca_attribute_movement_note" access="edit"/>
-        <permission table="ca_movements" bundle="ca_attribute_planned_removal_date" access="edit"/>
-        <permission table="ca_movements" bundle="ca_attribute_removal_date" access="edit"/>
-        <permission table="ca_movements" bundle="ca_attribute_movement_reason" access="edit"/>
-        <permission table="ca_movements" bundle="ca_object_representations" access="edit"/>
-        <permission table="ca_movements" bundle="ca_objects" access="edit"/>
-        <permission table="ca_movements" bundle="ca_object_lots" access="edit"/>
-        <permission table="ca_movements" bundle="ca_entities" access="edit"/>
-        <permission table="ca_movements" bundle="ca_occurrences" access="edit"/>
-        <permission table="ca_movements" bundle="ca_places" access="edit"/>
-        <permission table="ca_movements" bundle="ca_loans" access="edit"/>
-        <permission table="ca_movements" bundle="ca_movements" access="edit"/>
-        <permission table="ca_movements" bundle="ca_collections" access="edit"/>
-        <permission table="ca_movements" bundle="ca_storage_locations" access="edit"/>
-        <permission table="ca_movements" bundle="ca_list_items" access="edit"/>
-        <permission table="ca_tours" bundle="preferred_labels" access="edit"/>
-        <permission table="ca_tours" bundle="nonpreferred_labels" access="edit"/>
-        <permission table="ca_tours" bundle="tour_id" access="edit"/>
-        <permission table="ca_tours" bundle="tour_code" access="edit"/>
-        <permission table="ca_tours" bundle="rank" access="edit"/>
-        <permission table="ca_tours" bundle="color" access="edit"/>
-        <permission table="ca_tours" bundle="icon" access="edit"/>
-        <permission table="ca_tours" bundle="access" access="edit"/>
-        <permission table="ca_tours" bundle="status" access="edit"/>
-        <permission table="ca_tours" bundle="ca_attribute_tour_description" access="edit"/>
-        <permission table="ca_tours" bundle="ca_tour_stops_list" access="edit"/>
-        <permission table="ca_tour_stops" bundle="preferred_labels" access="edit"/>
-        <permission table="ca_tour_stops" bundle="nonpreferred_labels" access="edit"/>
-        <permission table="ca_tour_stops" bundle="stop_id" access="edit"/>
-        <permission table="ca_tour_stops" bundle="tour_id" access="edit"/>
-        <permission table="ca_tour_stops" bundle="idno" access="edit"/>
-        <permission table="ca_tour_stops" bundle="color" access="edit"/>
-        <permission table="ca_tour_stops" bundle="icon" access="edit"/>
-        <permission table="ca_tour_stops" bundle="rank" access="edit"/>
-        <permission table="ca_tour_stops" bundle="access" access="edit"/>
-        <permission table="ca_tour_stops" bundle="status" access="edit"/>
-        <permission table="ca_tour_stops" bundle="ca_attribute_tour_stop_description" access="edit"/>
-        <permission table="ca_tour_stops" bundle="ca_attribute_tour_stop_georeference" access="edit"/>
-        <permission table="ca_tour_stops" bundle="ca_objects" access="edit"/>
-        <permission table="ca_tour_stops" bundle="ca_entities" access="edit"/>
-        <permission table="ca_tour_stops" bundle="ca_places" access="edit"/>
-        <permission table="ca_tour_stops" bundle="ca_occurrences" access="edit"/>
-        <permission table="ca_tour_stops" bundle="ca_collections" access="edit"/>
-        <permission table="ca_tour_stops" bundle="ca_tour_stops" access="edit"/>
-        <permission table="ca_tour_stops" bundle="ca_list_items" access="edit"/>
-        <permission table="ca_tour_stops" bundle="hierarchy_navigation" access="edit"/>
-        <permission table="ca_tour_stops" bundle="hierarchy_location" access="edit"/>
-        <permission table="ca_object_representations" bundle="preferred_labels" access="edit"/>
-        <permission table="ca_object_representations" bundle="nonpreferred_labels" access="edit"/>
-        <permission table="ca_object_representations" bundle="representation_id" access="edit"/>
-        <permission table="ca_object_representations" bundle="locale_id" access="edit"/>
-        <permission table="ca_object_representations" bundle="idno" access="edit"/>
-        <permission table="ca_object_representations" bundle="media" access="edit"/>
-        <permission table="ca_object_representations" bundle="md5" access="edit"/>
-        <permission table="ca_object_representations" bundle="original_filename" access="edit"/>
-        <permission table="ca_object_representations" bundle="access" access="edit"/>
-        <permission table="ca_object_representations" bundle="status" access="edit"/>
-        <permission table="ca_object_representations" bundle="rank" access="edit"/>
-        <permission table="ca_object_representations" bundle="ca_attribute_caption" access="edit"/>
-        <permission table="ca_object_representations" bundle="ca_objects" access="edit"/>
-        <permission table="ca_object_representations" bundle="ca_entities" access="edit"/>
-        <permission table="ca_object_representations" bundle="ca_places" access="edit"/>
-        <permission table="ca_object_representations" bundle="ca_occurrences" access="edit"/>
-        <permission table="ca_object_representations" bundle="ca_representation_annotations" access="edit"/>
-        <permission table="ca_object_representations" bundle="ca_list_items" access="edit"/>
-        <permission table="ca_object_representations" bundle="ca_sets" access="edit"/>
-        <permission table="ca_object_representations" bundle="ca_loans" access="edit"/>
-        <permission table="ca_object_representations" bundle="ca_movements" access="edit"/>
-        <permission table="ca_object_representations" bundle="ca_object_lots" access="edit"/>
-        <permission table="ca_object_representations" bundle="ca_object_representations_media_display" access="edit"/>
-        <permission table="ca_object_representations" bundle="ca_object_representation_captions" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="preferred_labels" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="nonpreferred_labels" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="annotation_id" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="locale_id" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="user_id" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="preview" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="access" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="status" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="ca_attribute_caption" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="ca_objects" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="ca_entities" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="ca_places" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="ca_occurrences" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="ca_representation_annotation_properties" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="ca_list_items" access="edit"/>
-      </bundleLevelAccessControl>
-      <typeLevelAccessControl>
-        <permission table="ca_objects" type="anthropology" access="none"/>
-        <permission table="ca_objects" type="arachnid_myriapod" access="edit"/>
-        <permission table="ca_objects" type="DublinCore" access="none"/>
-        <permission table="ca_objects" type="DarwinCore" access="edit"/>
-        <permission table="ca_objects" type="Root node for object_types" access="none"/>
-        <permission table="ca_objects" type="tz" access="edit"/>
-        <permission table="ca_entities" type="ind" access="edit"/>
-        <permission table="ca_entities" type="org" access="edit"/>
-        <permission table="ca_entities" type="Root node for entity_types" access="none"/>
-        <permission table="ca_places" type="city" access="edit"/>
-        <permission table="ca_places" type="continent" access="edit"/>
-        <permission table="ca_places" type="country" access="edit"/>
-        <permission table="ca_places" type="cultural_area" access="edit"/>
-        <permission table="ca_places" type="islandGroup" access="edit"/>
-        <permission table="ca_places" type="island" access="edit"/>
-        <permission table="ca_places" type="location" access="edit"/>
-        <permission table="ca_places" type="neighborhood" access="edit"/>
-        <permission table="ca_places" type="other" access="edit"/>
-        <permission table="ca_places" type="river" access="edit"/>
-        <permission table="ca_places" type="Root node for place_types" access="none"/>
-        <permission table="ca_places" type="state" access="edit"/>
-        <permission table="ca_places" type="waterBody" access="edit"/>
-        <permission table="ca_occurrences" type="conservation_analysis" access="read"/>
-        <permission table="ca_occurrences" type="conservation_assignment" access="read"/>
-        <permission table="ca_occurrences" type="collectingEvent" access="edit"/>
-        <permission table="ca_occurrences" type="conservation" access="read"/>
-        <permission table="ca_occurrences" type="conservation_job" access="read"/>
-        <permission table="ca_occurrences" type="exhibition" access="read"/>
-        <permission table="ca_occurrences" type="anthropology_register" access="read"/>
-        <permission table="ca_occurrences" type="resource" access="edit"/>
-        <permission table="ca_occurrences" type="Root node for occurrence_types" access="none"/>
-        <permission table="ca_collections" type="external" access="edit"/>
-        <permission table="ca_collections" type="internal" access="read"/>
-        <permission table="ca_collections" type="Root node for collection_types" access="none"/>
-        <permission table="ca_object_lots" type="bequest" access="edit"/>
-        <permission table="ca_object_lots" type="gift" access="edit"/>
-        <permission table="ca_object_lots" type="loan" access="edit"/>
-        <permission table="ca_object_lots" type="long_term_loan" access="edit"/>
-        <permission table="ca_object_lots" type="purchase" access="edit"/>
-        <permission table="ca_object_lots" type="restricted_gift" access="edit"/>
-        <permission table="ca_object_lots" type="Root node for object_lot_types" access="none"/>
-        <permission table="ca_loans" type="in" access="edit"/>
-        <permission table="ca_loans" type="out" access="edit"/>
-        <permission table="ca_loans" type="Root node for loan_types" access="none"/>
-        <permission table="ca_movements" type="movement" access="edit"/>
-        <permission table="ca_movements" type="Root node for movement_types" access="none"/>
-        <permission table="ca_tours" type="full_length" access="read"/>
-        <permission table="ca_tours" type="Root node for tour_types" access="none"/>
-        <permission table="ca_tours" type="short" access="read"/>
-        <permission table="ca_tour_stops" type="secondary" access="read"/>
-        <permission table="ca_tour_stops" type="primary" access="read"/>
-        <permission table="ca_tour_stops" type="Root node for tour_stop_types" access="none"/>
-        <permission table="ca_object_representations" type="back" access="edit"/>
-        <permission table="ca_object_representations" type="front" access="edit"/>
-        <permission table="ca_object_representations" type="Root node for object_representation_types" access="none"/>
-      </typeLevelAccessControl>
-    </role>
-    <role code="anth_cataloguer">
-      <name>Anthropology Cataloguer</name>
-      <description/>
-      <actions>
-        <action>can_manage_system_search_forms</action>
-        <action>can_quicksearch</action>
-        <action>can_use_adv_search_forms</action>
-        <action>can_create_sets</action>
-        <action>can_edit_sets</action>
-        <action>can_delete_own_sets</action>
-        <action>can_view_sets</action>
-        <action>can_duplicate_ca_sets</action>
-        <action>can_create_ca_objects</action>
-        <action>can_edit_ca_objects</action>
-        <action>can_delete_ca_objects</action>
-        <action>can_search_ca_objects</action>
-        <action>can_browse_ca_objects</action>
-        <action>can_download_ca_object_representations</action>
-        <action>can_duplicate_ca_objects</action>
-        <action>can_export_ca_objects</action>
-        <action>can_change_acl_ca_objects</action>
-        <action>can_batch_edit_ca_objects</action>
-        <action>can_create_ca_object_representations</action>
-        <action>can_edit_ca_object_representations</action>
-        <action>can_delete_ca_object_representations</action>
-        <action>can_search_ca_object_representations</action>
-        <action>can_browse_ca_object_representations</action>
-        <action>can_duplicate_ca_object_representations</action>
-        <action>can_export_ca_object_representations</action>
-        <action>can_change_acl_ca_object_representations</action>
-        <action>can_batch_edit_ca_object_representations</action>
-        <action>can_create_ca_representation_annotations</action>
-        <action>can_edit_ca_representation_annotations</action>
-        <action>can_delete_ca_representation_annotations</action>
-        <action>can_search_ca_representation_annotations</action>
-        <action>can_browse_ca_representation_annotations</action>
-        <action>can_duplicate_ca_representation_annotations</action>
-        <action>can_change_acl_ca_representation_annotations</action>
-        <action>can_create_ca_entities</action>
-        <action>can_edit_ca_entities</action>
-        <action>can_delete_ca_entities</action>
-        <action>can_search_ca_entities</action>
-        <action>can_browse_ca_entities</action>
-        <action>can_duplicate_ca_entities</action>
-        <action>can_export_ca_entities</action>
-        <action>can_quickadd_ca_entities</action>
-        <action>can_change_acl_ca_entities</action>
-        <action>can_batch_edit_ca_entities</action>
-        <action>can_create_ca_places</action>
-        <action>can_edit_ca_places</action>
-        <action>can_delete_ca_places</action>
-        <action>can_search_ca_places</action>
-        <action>can_browse_ca_places</action>
-        <action>can_duplicate_ca_places</action>
-        <action>can_export_ca_places</action>
-        <action>can_quickadd_ca_places</action>
-        <action>can_change_acl_ca_places</action>
-        <action>can_batch_edit_ca_places</action>
-        <action>can_create_ca_occurrences</action>
-        <action>can_edit_ca_occurrences</action>
-        <action>can_delete_ca_occurrences</action>
-        <action>can_search_ca_occurrences</action>
-        <action>can_browse_ca_occurrences</action>
-        <action>can_duplicate_ca_occurrences</action>
-        <action>can_export_ca_occurrences</action>
-        <action>can_quickadd_ca_occurrences</action>
-        <action>can_change_acl_ca_occurrences</action>
-        <action>can_batch_edit_ca_occurrences</action>
-        <action>can_search_ca_collections</action>
-        <action>can_browse_ca_collections</action>
-        <action>can_change_acl_ca_collections</action>
-        <action>can_create_ca_storage_locations</action>
-        <action>can_edit_ca_storage_locations</action>
-        <action>can_delete_ca_storage_locations</action>
-        <action>can_search_ca_storage_locations</action>
-        <action>can_browse_ca_storage_locations</action>
-        <action>can_duplicate_ca_storage_locations</action>
-        <action>can_export_ca_storage_locations</action>
-        <action>can_quickadd_ca_storage_locations</action>
-        <action>can_change_type_ca_storage_locations</action>
-        <action>can_change_acl_ca_storage_locations</action>
-        <action>can_batch_edit_ca_storage_locations</action>
-        <action>can_create_ca_movements</action>
-        <action>can_edit_ca_movements</action>
-        <action>can_delete_ca_movements</action>
-        <action>can_search_ca_movements</action>
-        <action>can_browse_ca_movements</action>
-        <action>can_duplicate_ca_movements</action>
-        <action>can_export_ca_movements</action>
-        <action>can_quickadd_ca_movements</action>
-        <action>can_batch_edit_ca_movements</action>
-        <action>can_use_adv_search_form_widget</action>
-        <action>can_use_counts_widget</action>
-        <action>can_use_last_logins_widget</action>
-        <action>can_use_recent_changes_widget</action>
-        <action>can_use_recent_comment_widget</action>
-        <action>can_use_recent_tag_widget</action>
-        <action>can_use_recently_created_widget_ca_objects</action>
-        <action>can_use_recently_created_widget_ca_entities</action>
-        <action>can_use_recently_created_widget_ca_places</action>
-        <action>can_use_recently_created_widget_ca_occurrences</action>
-        <action>can_use_recently_created_widget_ca_sets</action>
-        <action>can_use_recently_created_widget_ca_collections</action>
-        <action>can_use_recently_created_widget_ca_object_representations</action>
-        <action>can_use_recently_created_widget_ca_object_lots</action>
-        <action>can_use_records_by_status_widget_ca_objects</action>
-        <action>can_use_records_by_status_widget_ca_entities</action>
-        <action>can_use_records_by_status_widget_ca_places</action>
-        <action>can_use_records_by_status_widget_ca_occurrences</action>
-        <action>can_use_records_by_status_widget_ca_sets</action>
-        <action>can_use_records_by_status_widget_ca_collections</action>
-        <action>can_use_records_by_status_widget_ca_object_representations</action>
-        <action>can_use_records_by_status_widget_ca_object_lots</action>
-        <action>can_use_track_processing_widget</action>
-      </actions>
-      <bundleLevelAccessControl>
-        <permission table="ca_objects" bundle="ca_attribute_GeologicalContext" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_SizeOrDuration" access="edit"/>
-        <permission table="ca_objects" bundle="access" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_accessionDate" access="edit"/>
-        <permission table="ca_objects" bundle="acl_inherit_from_ca_collections" access="edit"/>
-        <permission table="ca_objects" bundle="acl_inherit_from_parent" access="edit"/>
-        <permission table="ca_objects" bundle="acquisition_type_id" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_anthropologyMaterialTypes" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_associatedMedia" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_associatedSequences" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_associatedSpecimen" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_associatedTaxa" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_audit" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_behavior" access="edit"/>
-        <permission table="ca_objects" bundle="ca_collections" access="edit"/>
-        <permission table="ca_objects" bundle="ca_commerce_order_history" access="edit"/>
-        <permission table="ca_objects" bundle="ca_entities" access="edit"/>
-        <permission table="ca_objects" bundle="ca_list_items" access="edit"/>
-        <permission table="ca_objects" bundle="ca_loans" access="edit"/>
-        <permission table="ca_objects" bundle="ca_movements" access="edit"/>
-        <permission table="ca_objects" bundle="ca_object_lots" access="edit"/>
-        <permission table="ca_objects" bundle="ca_object_representations" access="edit"/>
-        <permission table="ca_objects" bundle="ca_objects" access="edit"/>
-        <permission table="ca_objects" bundle="ca_objects_components_list" access="edit"/>
-        <permission table="ca_objects" bundle="ca_objects_deaccession" access="edit"/>
-        <permission table="ca_objects" bundle="ca_objects_history" access="edit"/>
-        <permission table="ca_objects" bundle="ca_objects_location" access="edit"/>
-        <permission table="ca_objects" bundle="ca_occurrences" access="edit"/>
-        <permission table="ca_objects" bundle="ca_places" access="edit"/>
-        <permission table="ca_objects" bundle="ca_sets" access="edit"/>
-        <permission table="ca_objects" bundle="ca_storage_locations" access="edit"/>
-        <permission table="ca_objects" bundle="ca_tour_stops" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_collector_flag" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_colour" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_country" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_dataGeneralizations" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_dcBibCitation" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_dcLanguage" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_dcModified" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_dcRights" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_dcSubject" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_dcType" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_dctermscreated" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_description" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_description_source" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_determinationPlantsInverts" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_disposition" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_documentation" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_donation_date" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_dynamicProperties" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_earliestEonOrLowestEonothem" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_element" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_establishmentMeans" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_eventDate" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_eventRemarks" access="edit"/>
-        <permission table="ca_objects" bundle="extent" access="edit"/>
-        <permission table="ca_objects" bundle="extent_units" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_external_link" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_figured" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_francisStStore" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_geonames" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_georeference" access="edit"/>
-        <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
-        <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
-        <permission table="ca_objects" bundle="idno" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_individualCount" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_informationWithheld" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_institutionCode" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_institutionID" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_internal_notes" access="edit"/>
-        <permission table="ca_objects" bundle="item_status_id" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_languageAffiliation" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_languageName" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_lifeStage" access="edit"/>
-        <permission table="ca_objects" bundle="locale_id" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_maxDistAboveSurface" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_maximumElevationInMeters" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_minDistAboveSurface" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_mineral" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_minimumElevationInMeters" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_multipleMounts" access="edit"/>
-        <permission table="ca_objects" bundle="nonpreferred_labels" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_objectClassification" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_objectDetails" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_objectPublished" access="edit"/>
-        <permission table="ca_objects" bundle="object_id" access="read"/>
-        <permission table="ca_objects" bundle="ca_attribute_occurrenceDetails" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_occurrenceRemarks" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_occurrenceStatus" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_otherCatalogNumbers" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_ownerInstitutionCode" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_pointRadiusSpatialFit" access="edit"/>
-        <permission table="ca_objects" bundle="preferred_labels" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_preparations" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_quarantine" access="edit"/>
-        <permission table="ca_objects" bundle="rank" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_reared" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_recatalogued" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_relationship_info" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_reproductiveCondition" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_sex" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_sightedDetails" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_siteDetails" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_siteDetailsPalaeontology" access="edit"/>
-        <permission table="ca_objects" bundle="source_id" access="edit"/>
-        <permission table="ca_objects" bundle="status" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_storageLocationNotes" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_supportingDocumentation" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_technique" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_tradition" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_verbatimBioFlag" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_verbatimElevation" access="edit"/>
-        <permission table="ca_objects" bundle="ca_attribute_voucher" access="edit"/>
-        <permission table="ca_object_lots" bundle="access" access="read"/>
-        <permission table="ca_object_lots" bundle="ca_collections" access="read"/>
-        <permission table="ca_object_lots" bundle="ca_entities" access="read"/>
-        <permission table="ca_object_lots" bundle="ca_list_items" access="read"/>
-        <permission table="ca_object_lots" bundle="ca_loans" access="read"/>
-        <permission table="ca_object_lots" bundle="ca_movements" access="read"/>
-        <permission table="ca_object_lots" bundle="ca_object_lots" access="read"/>
-        <permission table="ca_object_lots" bundle="ca_object_representations" access="read"/>
-        <permission table="ca_object_lots" bundle="ca_objects" access="read"/>
-        <permission table="ca_object_lots" bundle="ca_occurrences" access="read"/>
-        <permission table="ca_object_lots" bundle="ca_places" access="read"/>
-        <permission table="ca_object_lots" bundle="ca_sets" access="read"/>
-        <permission table="ca_object_lots" bundle="ca_storage_locations" access="read"/>
-        <permission table="ca_object_lots" bundle="ca_attribute_dataGeneralizations" access="read"/>
-        <permission table="ca_object_lots" bundle="ca_attribute_dcBibCitation" access="read"/>
-        <permission table="ca_object_lots" bundle="ca_attribute_dcLanguage" access="read"/>
-        <permission table="ca_object_lots" bundle="ca_attribute_dcModified" access="read"/>
-        <permission table="ca_object_lots" bundle="ca_attribute_dcRights" access="read"/>
-        <permission table="ca_object_lots" bundle="ca_attribute_dcType" access="read"/>
-        <permission table="ca_object_lots" bundle="ca_attribute_description" access="read"/>
-        <permission table="ca_object_lots" bundle="ca_attribute_dynamicProperties" access="read"/>
-        <permission table="ca_object_lots" bundle="extent" access="read"/>
-        <permission table="ca_object_lots" bundle="extent_units" access="read"/>
-        <permission table="ca_object_lots" bundle="idno_stub" access="read"/>
-        <permission table="ca_object_lots" bundle="ca_attribute_informationWithheld" access="read"/>
-        <permission table="ca_object_lots" bundle="ca_attribute_institutionCode" access="read"/>
-        <permission table="ca_object_lots" bundle="ca_attribute_institutionID" access="read"/>
-        <permission table="ca_object_lots" bundle="lot_id" access="read"/>
-        <permission table="ca_object_lots" bundle="ca_attribute_lot_notes" access="read"/>
-        <permission table="ca_object_lots" bundle="lot_status_id" access="read"/>
-        <permission table="ca_object_lots" bundle="nonpreferred_labels" access="read"/>
-        <permission table="ca_object_lots" bundle="ca_attribute_ownerInstitutionCode" access="read"/>
-        <permission table="ca_object_lots" bundle="preferred_labels" access="read"/>
-        <permission table="ca_object_lots" bundle="rank" access="read"/>
-        <permission table="ca_object_lots" bundle="source_id" access="edit"/>
-        <permission table="ca_object_lots" bundle="status" access="read"/>
-        <permission table="ca_entities" bundle="access" access="edit"/>
-        <permission table="ca_entities" bundle="ca_attribute_address" access="edit"/>
-        <permission table="ca_entities" bundle="ca_attribute_biography" access="edit"/>
-        <permission table="ca_entities" bundle="ca_collections" access="edit"/>
-        <permission table="ca_entities" bundle="ca_entities" access="edit"/>
-        <permission table="ca_entities" bundle="ca_list_items" access="edit"/>
-        <permission table="ca_entities" bundle="ca_loans" access="edit"/>
-        <permission table="ca_entities" bundle="ca_movements" access="edit"/>
-        <permission table="ca_entities" bundle="ca_object_lots" access="edit"/>
-        <permission table="ca_entities" bundle="ca_object_representations" access="edit"/>
-        <permission table="ca_entities" bundle="ca_objects" access="edit"/>
-        <permission table="ca_entities" bundle="ca_occurrences" access="edit"/>
-        <permission table="ca_entities" bundle="ca_places" access="edit"/>
-        <permission table="ca_entities" bundle="ca_sets" access="edit"/>
-        <permission table="ca_entities" bundle="ca_storage_locations" access="edit"/>
-        <permission table="ca_entities" bundle="ca_tour_stops" access="edit"/>
-        <permission table="ca_entities" bundle="ca_attribute_email" access="edit"/>
-        <permission table="ca_entities" bundle="entity_id" access="edit"/>
-        <permission table="ca_entities" bundle="ca_attribute_external_link" access="edit"/>
-        <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
-        <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
-        <permission table="ca_entities" bundle="idno" access="edit"/>
-        <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
-        <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
-        <permission table="ca_entities" bundle="lifespan" access="edit"/>
-        <permission table="ca_entities" bundle="locale_id" access="edit"/>
-        <permission table="ca_entities" bundle="nonpreferred_labels" access="edit"/>
-        <permission table="ca_entities" bundle="preferred_labels" access="edit"/>
-        <permission table="ca_entities" bundle="rank" access="edit"/>
-        <permission table="ca_entities" bundle="ca_attribute_sex" access="edit"/>
-        <permission table="ca_entities" bundle="source_id" access="edit"/>
-        <permission table="ca_entities" bundle="status" access="edit"/>
-        <permission table="ca_entities" bundle="ca_attribute_telephone" access="edit"/>
-        <permission table="ca_entities" bundle="ca_attribute_url" access="edit"/>
-        <permission table="ca_places" bundle="access" access="none"/>
-        <permission table="ca_places" bundle="ca_collections" access="none"/>
-        <permission table="ca_places" bundle="ca_entities" access="none"/>
-        <permission table="ca_places" bundle="ca_list_items" access="none"/>
-        <permission table="ca_places" bundle="ca_loans" access="none"/>
-        <permission table="ca_places" bundle="ca_movements" access="none"/>
-        <permission table="ca_places" bundle="ca_object_lots" access="none"/>
-        <permission table="ca_places" bundle="ca_object_representations" access="none"/>
-        <permission table="ca_places" bundle="ca_objects" access="none"/>
-        <permission table="ca_places" bundle="ca_occurrences" access="none"/>
-        <permission table="ca_places" bundle="ca_places" access="none"/>
-        <permission table="ca_places" bundle="ca_sets" access="none"/>
-        <permission table="ca_places" bundle="ca_storage_locations" access="none"/>
-        <permission table="ca_places" bundle="ca_tour_stops" access="none"/>
-        <permission table="ca_places" bundle="ca_attribute_country" access="none"/>
-        <permission table="ca_places" bundle="ca_attribute_dataGeneralizations" access="none"/>
-        <permission table="ca_places" bundle="ca_attribute_dcBibCitation" access="none"/>
-        <permission table="ca_places" bundle="ca_attribute_dcLanguage" access="none"/>
-        <permission table="ca_places" bundle="ca_attribute_dcModified" access="none"/>
-        <permission table="ca_places" bundle="ca_attribute_dcRights" access="none"/>
-        <permission table="ca_places" bundle="ca_attribute_dcType" access="none"/>
-        <permission table="ca_places" bundle="ca_attribute_description" access="none"/>
-        <permission table="ca_places" bundle="ca_attribute_description_source" access="none"/>
-        <permission table="ca_places" bundle="ca_attribute_dynamicProperties" access="none"/>
-        <permission table="ca_places" bundle="ca_attribute_external_link" access="none"/>
-        <permission table="ca_places" bundle="ca_attribute_geonames" access="none"/>
-        <permission table="ca_places" bundle="ca_attribute_georeference" access="none"/>
-        <permission table="ca_places" bundle="hierarchy_location" access="none"/>
-        <permission table="ca_places" bundle="hierarchy_navigation" access="none"/>
-        <permission table="ca_places" bundle="idno" access="none"/>
-        <permission table="ca_places" bundle="ca_attribute_informationWithheld" access="none"/>
-        <permission table="ca_places" bundle="ca_attribute_institutionCode" access="none"/>
-        <permission table="ca_places" bundle="ca_attribute_institutionID" access="none"/>
-        <permission table="ca_places" bundle="ca_attribute_internal_notes" access="none"/>
-        <permission table="ca_places" bundle="ca_attribute_languageAffiliation" access="none"/>
-        <permission table="ca_places" bundle="lifespan" access="none"/>
-        <permission table="ca_places" bundle="locale_id" access="none"/>
-        <permission table="ca_places" bundle="ca_attribute_maxDistAboveSurface" access="none"/>
-        <permission table="ca_places" bundle="ca_attribute_maximumElevationInMeters" access="none"/>
-        <permission table="ca_places" bundle="ca_attribute_minDistAboveSurface" access="none"/>
-        <permission table="ca_places" bundle="ca_attribute_minimumElevationInMeters" access="none"/>
-        <permission table="ca_places" bundle="nonpreferred_labels" access="none"/>
-        <permission table="ca_places" bundle="ca_attribute_occurrenceDetails" access="none"/>
-        <permission table="ca_places" bundle="ca_attribute_occurrenceRemarks" access="none"/>
-        <permission table="ca_places" bundle="ca_attribute_ownerInstitutionCode" access="none"/>
-        <permission table="ca_places" bundle="parent_id" access="none"/>
-        <permission table="ca_places" bundle="place_id" access="none"/>
-        <permission table="ca_places" bundle="ca_attribute_pointRadiusSpatialFit" access="none"/>
-        <permission table="ca_places" bundle="preferred_labels" access="none"/>
-        <permission table="ca_places" bundle="rank" access="none"/>
-        <permission table="ca_places" bundle="source_id" access="none"/>
-        <permission table="ca_places" bundle="status" access="none"/>
-        <permission table="ca_places" bundle="ca_attribute_verbatimElevation" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_AnalysisReceived" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_AnalysisRequested" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_Archive" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_ArtefactList" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_AssignmentDates" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_AssignmentTimeMaterials" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_BWNeg" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_CDRom" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_CNeg" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_ConservationSlide" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_ExcelReference" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_Video" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="none"/>
-        <permission table="ca_occurrences" bundle="access" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_associatedSequences" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_behavior" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_collections" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_entities" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_list_items" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_loans" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_movements" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_object_lots" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_object_representations" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_objects" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_occurrences" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_places" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_sets" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_storage_locations" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_tour_stops" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_country" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_dcModified" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_dcRights" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_description" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_earliestEonOrLowestEonothem" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_establishmentMeans" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_eventDate" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_eventRemarks" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_eventTime" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_external_link" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_georeference" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_habitat" access="none"/>
-        <permission table="ca_occurrences" bundle="hierarchy_location" access="none"/>
-        <permission table="ca_occurrences" bundle="hierarchy_navigation" access="none"/>
-        <permission table="ca_occurrences" bundle="idno" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_informationWithheld" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_institutionCode" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_institutionID" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_internal_notes" access="none"/>
-        <permission table="ca_occurrences" bundle="locale_id" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_locationRemarks" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_maxDistAboveSurface" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_maximumDepthInMeters" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_maximumElevationInMeters" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_measurementOrFact" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_media" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_minDistAboveSurface" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_minimumDepthInMeters" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_minimumElevationInMeters" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_noPages" access="none"/>
-        <permission table="ca_occurrences" bundle="nonpreferred_labels" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_occurrenceDetails" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_occurrenceRemarks" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_occurrenceStatus" access="none"/>
-        <permission table="ca_occurrences" bundle="occurrence_id" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_otherCatalogNumbers" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_ownerInstitutionCode" access="none"/>
-        <permission table="ca_occurrences" bundle="parent_id" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_pointRadiusSpatialFit" access="none"/>
-        <permission table="ca_occurrences" bundle="preferred_labels" access="none"/>
-        <permission table="ca_occurrences" bundle="rank" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_recordNumber" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_registerClassification" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_registerRecordData" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_reproductiveCondition" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_resourceDateRange" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_rft_pages" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_rft_volume" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_samplingEffort" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_samplingProtocol" access="none"/>
-        <permission table="ca_occurrences" bundle="source_id" access="none"/>
-        <permission table="ca_occurrences" bundle="status" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_substrate" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_verbatimDepth" access="none"/>
-        <permission table="ca_occurrences" bundle="ca_attribute_verbatimElevation" access="none"/>
-        <permission table="ca_collections" bundle="access" access="read"/>
-        <permission table="ca_collections" bundle="acl_inherit_from_parent" access="read"/>
-        <permission table="ca_collections" bundle="ca_collections" access="read"/>
-        <permission table="ca_collections" bundle="ca_entities" access="read"/>
-        <permission table="ca_collections" bundle="ca_list_items" access="read"/>
-        <permission table="ca_collections" bundle="ca_loans" access="read"/>
-        <permission table="ca_collections" bundle="ca_movements" access="read"/>
-        <permission table="ca_collections" bundle="ca_object_lots" access="read"/>
-        <permission table="ca_collections" bundle="ca_object_representations" access="read"/>
-        <permission table="ca_collections" bundle="ca_objects" access="read"/>
-        <permission table="ca_collections" bundle="ca_occurrences" access="read"/>
-        <permission table="ca_collections" bundle="ca_places" access="read"/>
-        <permission table="ca_collections" bundle="ca_sets" access="read"/>
-        <permission table="ca_collections" bundle="ca_storage_locations" access="read"/>
-        <permission table="ca_collections" bundle="ca_tour_stops" access="read"/>
-        <permission table="ca_collections" bundle="collection_id" access="read"/>
-        <permission table="ca_collections" bundle="ca_attribute_country" access="read"/>
-        <permission table="ca_collections" bundle="ca_attribute_dataGeneralizations" access="read"/>
-        <permission table="ca_collections" bundle="ca_attribute_dcBibCitation" access="read"/>
-        <permission table="ca_collections" bundle="ca_attribute_dcLanguage" access="read"/>
-        <permission table="ca_collections" bundle="ca_attribute_dcModified" access="read"/>
-        <permission table="ca_collections" bundle="ca_attribute_dcRights" access="read"/>
-        <permission table="ca_collections" bundle="ca_attribute_dcType" access="read"/>
-        <permission table="ca_collections" bundle="ca_attribute_description" access="read"/>
-        <permission table="ca_collections" bundle="ca_attribute_description_source" access="read"/>
-        <permission table="ca_collections" bundle="ca_attribute_dynamicProperties" access="read"/>
-        <permission table="ca_collections" bundle="ca_attribute_earliestEonOrLowestEonothem" access="read"/>
-        <permission table="ca_collections" bundle="ca_attribute_external_link" access="read"/>
-        <permission table="ca_collections" bundle="hierarchy_location" access="read"/>
-        <permission table="ca_collections" bundle="hierarchy_navigation" access="read"/>
-        <permission table="ca_collections" bundle="idno" access="read"/>
-        <permission table="ca_collections" bundle="ca_attribute_informationWithheld" access="read"/>
-        <permission table="ca_collections" bundle="ca_attribute_institutionCode" access="read"/>
-        <permission table="ca_collections" bundle="ca_attribute_institutionID" access="read"/>
-        <permission table="ca_collections" bundle="ca_attribute_internal_notes" access="read"/>
-        <permission table="ca_collections" bundle="locale_id" access="read"/>
-        <permission table="ca_collections" bundle="ca_attribute_maxDistAboveSurface" access="read"/>
-        <permission table="ca_collections" bundle="ca_attribute_maximumElevationInMeters" access="read"/>
-        <permission table="ca_collections" bundle="ca_attribute_minDistAboveSurface" access="read"/>
-        <permission table="ca_collections" bundle="ca_attribute_minimumElevationInMeters" access="read"/>
-        <permission table="ca_collections" bundle="nonpreferred_labels" access="read"/>
-        <permission table="ca_collections" bundle="ca_attribute_occurrenceDetails" access="read"/>
-        <permission table="ca_collections" bundle="ca_attribute_occurrenceRemarks" access="read"/>
-        <permission table="ca_collections" bundle="ca_attribute_ownerInstitutionCode" access="read"/>
-        <permission table="ca_collections" bundle="ca_attribute_pointRadiusSpatialFit" access="read"/>
-        <permission table="ca_collections" bundle="preferred_labels" access="read"/>
-        <permission table="ca_collections" bundle="rank" access="read"/>
-        <permission table="ca_collections" bundle="source_id" access="read"/>
-        <permission table="ca_collections" bundle="status" access="read"/>
-        <permission table="ca_collections" bundle="ca_attribute_verbatimElevation" access="read"/>
-        <permission table="ca_storage_locations" bundle="access" access="edit"/>
-        <permission table="ca_storage_locations" bundle="ca_attribute_address" access="edit"/>
-        <permission table="ca_storage_locations" bundle="ca_collections" access="edit"/>
-        <permission table="ca_storage_locations" bundle="ca_entities" access="edit"/>
-        <permission table="ca_storage_locations" bundle="ca_list_items" access="edit"/>
-        <permission table="ca_storage_locations" bundle="ca_loans" access="edit"/>
-        <permission table="ca_storage_locations" bundle="ca_movements" access="edit"/>
-        <permission table="ca_storage_locations" bundle="ca_object_lots" access="edit"/>
-        <permission table="ca_storage_locations" bundle="ca_object_representations" access="edit"/>
-        <permission table="ca_storage_locations" bundle="ca_objects" access="edit"/>
-        <permission table="ca_storage_locations" bundle="ca_occurrences" access="edit"/>
-        <permission table="ca_storage_locations" bundle="ca_places" access="edit"/>
-        <permission table="ca_storage_locations" bundle="ca_sets" access="edit"/>
-        <permission table="ca_storage_locations" bundle="ca_storage_locations" access="edit"/>
-        <permission table="ca_storage_locations" bundle="color" access="edit"/>
-        <permission table="ca_storage_locations" bundle="ca_attribute_dataGeneralizations" access="edit"/>
-        <permission table="ca_storage_locations" bundle="ca_attribute_dcBibCitation" access="edit"/>
-        <permission table="ca_storage_locations" bundle="ca_attribute_dcLanguage" access="edit"/>
-        <permission table="ca_storage_locations" bundle="ca_attribute_dcModified" access="edit"/>
-        <permission table="ca_storage_locations" bundle="ca_attribute_dcRights" access="edit"/>
-        <permission table="ca_storage_locations" bundle="ca_attribute_dcType" access="edit"/>
-        <permission table="ca_storage_locations" bundle="ca_attribute_description" access="edit"/>
-        <permission table="ca_storage_locations" bundle="ca_attribute_dynamicProperties" access="edit"/>
-        <permission table="ca_storage_locations" bundle="ca_attribute_georeference" access="edit"/>
-        <permission table="ca_storage_locations" bundle="hierarchy_location" access="edit"/>
-        <permission table="ca_storage_locations" bundle="hierarchy_navigation" access="edit"/>
-        <permission table="ca_storage_locations" bundle="icon" access="edit"/>
-        <permission table="ca_storage_locations" bundle="idno" access="edit"/>
-        <permission table="ca_storage_locations" bundle="ca_attribute_informationWithheld" access="edit"/>
-        <permission table="ca_storage_locations" bundle="ca_attribute_institutionCode" access="edit"/>
-        <permission table="ca_storage_locations" bundle="ca_attribute_institutionID" access="edit"/>
-        <permission table="ca_storage_locations" bundle="ca_attribute_internal_notes" access="edit"/>
-        <permission table="ca_storage_locations" bundle="location_id" access="edit"/>
-        <permission table="ca_storage_locations" bundle="nonpreferred_labels" access="edit"/>
-        <permission table="ca_storage_locations" bundle="ca_attribute_ownerInstitutionCode" access="edit"/>
-        <permission table="ca_storage_locations" bundle="preferred_labels" access="edit"/>
-        <permission table="ca_storage_locations" bundle="rank" access="edit"/>
-        <permission table="ca_storage_locations" bundle="source_id" access="edit"/>
-        <permission table="ca_storage_locations" bundle="status" access="edit"/>
-        <permission table="ca_loans" bundle="access" access="edit"/>
-        <permission table="ca_loans" bundle="ca_collections" access="none"/>
-        <permission table="ca_loans" bundle="ca_entities" access="none"/>
-        <permission table="ca_loans" bundle="ca_list_items" access="none"/>
-        <permission table="ca_loans" bundle="ca_loans" access="none"/>
-        <permission table="ca_loans" bundle="ca_movements" access="none"/>
-        <permission table="ca_loans" bundle="ca_object_lots" access="none"/>
-        <permission table="ca_loans" bundle="ca_object_representations" access="none"/>
-        <permission table="ca_loans" bundle="ca_objects" access="none"/>
-        <permission table="ca_loans" bundle="ca_occurrences" access="none"/>
-        <permission table="ca_loans" bundle="ca_places" access="none"/>
-        <permission table="ca_loans" bundle="ca_storage_locations" access="none"/>
-        <permission table="ca_loans" bundle="idno" access="none"/>
-        <permission table="ca_loans" bundle="ca_attribute_loan_authorization_date" access="none"/>
-        <permission table="ca_loans" bundle="ca_attribute_loan_conditions" access="none"/>
-        <permission table="ca_loans" bundle="loan_id" access="none"/>
-        <permission table="ca_loans" bundle="ca_attribute_loan_in_date" access="none"/>
-        <permission table="ca_loans" bundle="ca_attribute_loan_note" access="none"/>
-        <permission table="ca_loans" bundle="ca_attribute_loan_out_date" access="none"/>
-        <permission table="ca_loans" bundle="ca_attribute_loan_purpose" access="none"/>
-        <permission table="ca_loans" bundle="ca_attribute_loan_renewal_date" access="none"/>
-        <permission table="ca_loans" bundle="ca_attribute_loan_return_date" access="none"/>
-        <permission table="ca_loans" bundle="ca_attribute_loan_status" access="edit"/>
-        <permission table="ca_loans" bundle="nonpreferred_labels" access="none"/>
-        <permission table="ca_loans" bundle="preferred_labels" access="none"/>
-        <permission table="ca_loans" bundle="rank" access="none"/>
-        <permission table="ca_loans" bundle="source_id" access="edit"/>
-        <permission table="ca_loans" bundle="status" access="none"/>
-        <permission table="ca_movements" bundle="access" access="edit"/>
-        <permission table="ca_movements" bundle="ca_collections" access="edit"/>
-        <permission table="ca_movements" bundle="ca_entities" access="edit"/>
-        <permission table="ca_movements" bundle="ca_list_items" access="edit"/>
-        <permission table="ca_movements" bundle="ca_loans" access="edit"/>
-        <permission table="ca_movements" bundle="ca_movements" access="edit"/>
-        <permission table="ca_movements" bundle="ca_object_lots" access="edit"/>
-        <permission table="ca_movements" bundle="ca_object_representations" access="edit"/>
-        <permission table="ca_movements" bundle="ca_objects" access="edit"/>
-        <permission table="ca_movements" bundle="ca_occurrences" access="edit"/>
-        <permission table="ca_movements" bundle="ca_places" access="edit"/>
-        <permission table="ca_movements" bundle="ca_storage_locations" access="edit"/>
-        <permission table="ca_movements" bundle="idno" access="edit"/>
-        <permission table="ca_movements" bundle="movement_id" access="edit"/>
-        <permission table="ca_movements" bundle="ca_attribute_movement_method" access="edit"/>
-        <permission table="ca_movements" bundle="ca_attribute_movement_note" access="edit"/>
-        <permission table="ca_movements" bundle="ca_attribute_movement_reason" access="edit"/>
-        <permission table="ca_movements" bundle="nonpreferred_labels" access="edit"/>
-        <permission table="ca_movements" bundle="ca_attribute_planned_removal_date" access="edit"/>
-        <permission table="ca_movements" bundle="preferred_labels" access="edit"/>
-        <permission table="ca_movements" bundle="rank" access="edit"/>
-        <permission table="ca_movements" bundle="ca_attribute_removal_date" access="edit"/>
-        <permission table="ca_movements" bundle="source_id" access="edit"/>
-        <permission table="ca_movements" bundle="status" access="edit"/>
-        <permission table="ca_object_representations" bundle="access" access="edit"/>
-        <permission table="ca_object_representations" bundle="ca_entities" access="edit"/>
-        <permission table="ca_object_representations" bundle="ca_list_items" access="edit"/>
-        <permission table="ca_object_representations" bundle="ca_loans" access="edit"/>
-        <permission table="ca_object_representations" bundle="ca_movements" access="edit"/>
-        <permission table="ca_object_representations" bundle="ca_object_lots" access="edit"/>
-        <permission table="ca_object_representations" bundle="ca_object_representation_captions" access="edit"/>
-        <permission table="ca_object_representations" bundle="ca_object_representations_media_display" access="edit"/>
-        <permission table="ca_object_representations" bundle="ca_objects" access="edit"/>
-        <permission table="ca_object_representations" bundle="ca_occurrences" access="edit"/>
-        <permission table="ca_object_representations" bundle="ca_places" access="edit"/>
-        <permission table="ca_object_representations" bundle="ca_representation_annotations" access="edit"/>
-        <permission table="ca_object_representations" bundle="ca_sets" access="edit"/>
-        <permission table="ca_object_representations" bundle="ca_attribute_caption" access="edit"/>
-        <permission table="ca_object_representations" bundle="idno" access="edit"/>
-        <permission table="ca_object_representations" bundle="locale_id" access="edit"/>
-        <permission table="ca_object_representations" bundle="md5" access="edit"/>
-        <permission table="ca_object_representations" bundle="media" access="edit"/>
-        <permission table="ca_object_representations" bundle="nonpreferred_labels" access="edit"/>
-        <permission table="ca_object_representations" bundle="original_filename" access="edit"/>
-        <permission table="ca_object_representations" bundle="preferred_labels" access="edit"/>
-        <permission table="ca_object_representations" bundle="rank" access="edit"/>
-        <permission table="ca_object_representations" bundle="representation_id" access="edit"/>
-        <permission table="ca_object_representations" bundle="source_id" access="edit"/>
-        <permission table="ca_object_representations" bundle="status" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="access" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="annotation_id" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="ca_entities" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="ca_list_items" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="ca_objects" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="ca_occurrences" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="ca_places" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="ca_representation_annotation_properties" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="ca_attribute_caption" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="locale_id" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="nonpreferred_labels" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="preferred_labels" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="preview" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="status" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="user_id" access="edit"/>
-        <permission table="ca_sets" bundle="access" access="edit"/>
-        <permission table="ca_sets" bundle="ca_set_items" access="edit"/>
-        <permission table="ca_sets" bundle="ca_user_groups" access="edit"/>
-        <permission table="ca_sets" bundle="ca_users" access="edit"/>
-        <permission table="ca_sets" bundle="nonpreferred_labels" access="edit"/>
-        <permission table="ca_sets" bundle="preferred_labels" access="edit"/>
-        <permission table="ca_sets" bundle="rank" access="edit"/>
-        <permission table="ca_sets" bundle="ca_attribute_set_chron_date_element_code" access="edit"/>
-        <permission table="ca_sets" bundle="set_code" access="edit"/>
-        <permission table="ca_sets" bundle="ca_attribute_set_description" access="edit"/>
-        <permission table="ca_sets" bundle="set_id" access="edit"/>
-        <permission table="ca_sets" bundle="ca_attribute_set_presentation_type" access="edit"/>
-        <permission table="ca_sets" bundle="status" access="edit"/>
-        <permission table="ca_set_items" bundle="ca_attribute_caption" access="edit"/>
-        <permission table="ca_set_items" bundle="item_id" access="edit"/>
-        <permission table="ca_set_items" bundle="nonpreferred_labels" access="edit"/>
-        <permission table="ca_set_items" bundle="preferred_labels" access="edit"/>
-        <permission table="ca_set_items" bundle="row_id" access="edit"/>
-        <permission table="ca_set_items" bundle="ca_attribute_set_item_description" access="edit"/>
-        <permission table="ca_set_items" bundle="ca_attribute_set_item_is_primary" access="edit"/>
-        <permission table="ca_set_items" bundle="table_num" access="edit"/>
-        <permission table="ca_lists" bundle="default_sort" access="edit"/>
-        <permission table="ca_lists" bundle="is_hierarchical" access="edit"/>
-        <permission table="ca_lists" bundle="is_system_list" access="edit"/>
-        <permission table="ca_lists" bundle="list_code" access="edit"/>
-        <permission table="ca_lists" bundle="list_id" access="edit"/>
-        <permission table="ca_lists" bundle="nonpreferred_labels" access="edit"/>
-        <permission table="ca_lists" bundle="preferred_labels" access="edit"/>
-        <permission table="ca_lists" bundle="use_as_vocabulary" access="edit"/>
-        <permission table="ca_list_items" bundle="access" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_collections" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_entities" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_list_items" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_loans" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_movements" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_object_lots" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_object_representations" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_objects" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_occurrences" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_places" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_storage_locations" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_attribute_caabFamilyNo" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_attribute_chemical_formula" access="edit"/>
-        <permission table="ca_list_items" bundle="color" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_attribute_element" access="edit"/>
-        <permission table="ca_list_items" bundle="hierarchy_location" access="edit"/>
-        <permission table="ca_list_items" bundle="hierarchy_navigation" access="edit"/>
-        <permission table="ca_list_items" bundle="icon" access="edit"/>
-        <permission table="ca_list_items" bundle="idno" access="edit"/>
-        <permission table="ca_list_items" bundle="is_default" access="edit"/>
-        <permission table="ca_list_items" bundle="is_enabled" access="edit"/>
-        <permission table="ca_list_items" bundle="item_id" access="edit"/>
-        <permission table="ca_list_items" bundle="item_value" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_attribute_namePublishedInYear" access="edit"/>
-        <permission table="ca_list_items" bundle="nonpreferred_labels" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_attribute_parentheticalAuthor" access="edit"/>
-        <permission table="ca_list_items" bundle="preferred_labels" access="edit"/>
-        <permission table="ca_list_items" bundle="rank" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_attribute_scientificNameAuthorship" access="edit"/>
-        <permission table="ca_list_items" bundle="settings" access="edit"/>
-        <permission table="ca_list_items" bundle="source_id" access="edit"/>
-        <permission table="ca_list_items" bundle="status" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_attribute_taxonRank" access="edit"/>
-        <permission table="ca_tours" bundle="access" access="none"/>
-        <permission table="ca_tours" bundle="ca_tour_stops_list" access="none"/>
-        <permission table="ca_tours" bundle="color" access="none"/>
-        <permission table="ca_tours" bundle="icon" access="none"/>
-        <permission table="ca_tours" bundle="nonpreferred_labels" access="none"/>
-        <permission table="ca_tours" bundle="preferred_labels" access="none"/>
-        <permission table="ca_tours" bundle="rank" access="none"/>
-        <permission table="ca_tours" bundle="source_id" access="edit"/>
-        <permission table="ca_tours" bundle="status" access="none"/>
-        <permission table="ca_tours" bundle="tour_code" access="none"/>
-        <permission table="ca_tours" bundle="ca_attribute_tour_description" access="none"/>
-        <permission table="ca_tours" bundle="tour_id" access="none"/>
-        <permission table="ca_tour_stops" bundle="access" access="none"/>
-        <permission table="ca_tour_stops" bundle="ca_collections" access="none"/>
-        <permission table="ca_tour_stops" bundle="ca_entities" access="none"/>
-        <permission table="ca_tour_stops" bundle="ca_list_items" access="none"/>
-        <permission table="ca_tour_stops" bundle="ca_objects" access="none"/>
-        <permission table="ca_tour_stops" bundle="ca_occurrences" access="none"/>
-        <permission table="ca_tour_stops" bundle="ca_places" access="none"/>
-        <permission table="ca_tour_stops" bundle="ca_tour_stops" access="none"/>
-        <permission table="ca_tour_stops" bundle="color" access="none"/>
-        <permission table="ca_tour_stops" bundle="hierarchy_location" access="none"/>
-        <permission table="ca_tour_stops" bundle="hierarchy_navigation" access="none"/>
-        <permission table="ca_tour_stops" bundle="icon" access="none"/>
-        <permission table="ca_tour_stops" bundle="idno" access="none"/>
-        <permission table="ca_tour_stops" bundle="nonpreferred_labels" access="none"/>
-        <permission table="ca_tour_stops" bundle="preferred_labels" access="none"/>
-        <permission table="ca_tour_stops" bundle="rank" access="none"/>
-        <permission table="ca_tour_stops" bundle="status" access="none"/>
-        <permission table="ca_tour_stops" bundle="stop_id" access="none"/>
-        <permission table="ca_tour_stops" bundle="tour_id" access="none"/>
-        <permission table="ca_tour_stops" bundle="ca_attribute_tour_stop_description" access="none"/>
-        <permission table="ca_tour_stops" bundle="ca_attribute_tour_stop_georeference" access="none"/>
-      </bundleLevelAccessControl>
-      <typeLevelAccessControl>
-        <permission table="ca_objects" type="anthropology" access="edit"/>
-        <permission table="ca_objects" type="az" access="none"/>
-        <permission table="ca_objects" type="arachnid_myriapod" access="none"/>
-        <permission table="ca_objects" type="crustacea" access="none"/>
-        <permission table="ca_objects" type="DublinCore" access="edit"/>
-        <permission table="ca_objects" type="insect" access="none"/>
-        <permission table="ca_objects" type="eps" access="none"/>
-        <permission table="ca_objects" type="fish" access="none"/>
-        <permission table="ca_objects" type="history" access="read"/>
-        <permission table="ca_objects" type="early_childhood" access="read"/>
-        <permission table="ca_objects" type="invertebrate_palaeontology" access="none"/>
-        <permission table="ca_objects" type="mammal" access="none"/>
-        <permission table="ca_objects" type="mineral" access="none"/>
-        <permission table="ca_objects" type="mineral_mdc" access="none"/>
-        <permission table="ca_objects" type="mineral_simpson" access="none"/>
-        <permission table="ca_objects" type="miz" access="none"/>
-        <permission table="ca_objects" type="mollusc" access="none"/>
-        <permission table="ca_objects" type="DarwinCore" access="none"/>
-        <permission table="ca_objects" type="bird" access="none"/>
-        <permission table="ca_objects" type="reptile" access="none"/>
-        <permission table="ca_objects" type="Root node for object_types" access="none"/>
-        <permission table="ca_objects" type="tz" access="none"/>
-        <permission table="ca_objects" type="vertebrate_palaeontology" access="none"/>
-        <permission table="ca_objects" type="worm" access="none"/>
-        <permission table="ca_object_lots" type="bequest" access="edit"/>
-        <permission table="ca_object_lots" type="gift" access="edit"/>
-        <permission table="ca_object_lots" type="loan" access="none"/>
-        <permission table="ca_object_lots" type="long_term_loan" access="none"/>
-        <permission table="ca_object_lots" type="purchase" access="edit"/>
-        <permission table="ca_object_lots" type="restricted_gift" access="edit"/>
-        <permission table="ca_object_lots" type="Root node for object_lot_types" access="none"/>
-        <permission table="ca_entities" type="ind" access="edit"/>
-        <permission table="ca_entities" type="org" access="edit"/>
-        <permission table="ca_entities" type="Root node for entity_types" access="none"/>
-        <permission table="ca_places" type="city" access="edit"/>
-        <permission table="ca_places" type="continent" access="read"/>
-        <permission table="ca_places" type="country" access="edit"/>
-        <permission table="ca_places" type="cultural_area" access="edit"/>
-        <permission table="ca_places" type="islandGroup" access="edit"/>
-        <permission table="ca_places" type="island" access="edit"/>
-        <permission table="ca_places" type="location" access="edit"/>
-        <permission table="ca_places" type="neighborhood" access="edit"/>
-        <permission table="ca_places" type="other" access="edit"/>
-        <permission table="ca_places" type="region" access="edit"/>
-        <permission table="ca_places" type="river" access="edit"/>
-        <permission table="ca_places" type="Root node for place_types" access="none"/>
-        <permission table="ca_places" type="site" access="edit"/>
-        <permission table="ca_places" type="state" access="edit"/>
-        <permission table="ca_places" type="waterBody" access="edit"/>
-        <permission table="ca_occurrences" type="conservation_analysis" access="none"/>
-        <permission table="ca_occurrences" type="conservation_assignment" access="none"/>
-        <permission table="ca_occurrences" type="collectingEvent" access="read"/>
-        <permission table="ca_occurrences" type="conservation" access="edit"/>
-        <permission table="ca_occurrences" type="conservation_job" access="none"/>
-        <permission table="ca_occurrences" type="exhibition" access="edit"/>
-        <permission table="ca_occurrences" type="map" access="edit"/>
-        <permission table="ca_occurrences" type="anthropology_register" access="edit"/>
-        <permission table="ca_occurrences" type="resource" access="edit"/>
-        <permission table="ca_occurrences" type="Root node for occurrence_types" access="none"/>
-        <permission table="ca_collections" type="external" access="read"/>
-        <permission table="ca_collections" type="internal" access="read"/>
-        <permission table="ca_collections" type="Root node for collection_types" access="none"/>
-        <permission table="ca_storage_locations" type="building" access="read"/>
-        <permission table="ca_storage_locations" type="cabinet" access="edit"/>
-        <permission table="ca_storage_locations" type="column" access="edit"/>
-        <permission table="ca_storage_locations" type="drawer" access="edit"/>
-        <permission table="ca_storage_locations" type="drum" access="edit"/>
-        <permission table="ca_storage_locations" type="floor" access="read"/>
-        <permission table="ca_storage_locations" type="pallet" access="edit"/>
-        <permission table="ca_storage_locations" type="room" access="read"/>
-        <permission table="ca_storage_locations" type="Root node for storage_location_types" access="none"/>
-        <permission table="ca_storage_locations" type="row" access="edit"/>
-        <permission table="ca_storage_locations" type="shelf" access="edit"/>
-        <permission table="ca_storage_locations" type="site" access="read"/>
-        <permission table="ca_loans" type="custodial" access="edit"/>
-        <permission table="ca_loans" type="in" access="edit"/>
-        <permission table="ca_loans" type="out" access="edit"/>
-        <permission table="ca_loans" type="Root node for loan_types" access="none"/>
-        <permission table="ca_movements" type="movement" access="edit"/>
-        <permission table="ca_movements" type="Root node for movement_types" access="none"/>
-        <permission table="ca_object_representations" type="back" access="edit"/>
-        <permission table="ca_object_representations" type="front" access="edit"/>
-        <permission table="ca_object_representations" type="Root node for object_representation_types" access="none"/>
-        <permission table="ca_sets" type="public_presentation" access="edit"/>
-        <permission table="ca_sets" type="Root node for set_types" access="none"/>
-        <permission table="ca_sets" type="user" access="edit"/>
-        <permission table="ca_set_items" type="public_presentation" access="edit"/>
-        <permission table="ca_set_items" type="Root node for set_types" access="none"/>
-        <permission table="ca_set_items" type="user" access="edit"/>
-        <permission table="ca_list_items" type="concept" access="edit"/>
-        <permission table="ca_list_items" type="mineral" access="read"/>
-        <permission table="ca_list_items" type="Root node for list_item_types" access="none"/>
-        <permission table="ca_list_items" type="scientific_name" access="read"/>
-        <permission table="ca_tours" type="full_length" access="none"/>
-        <permission table="ca_tours" type="Root node for tour_types" access="none"/>
-        <permission table="ca_tours" type="short" access="none"/>
-        <permission table="ca_tour_stops" type="secondary" access="none"/>
-        <permission table="ca_tour_stops" type="primary" access="none"/>
-        <permission table="ca_tour_stops" type="Root node for tour_stop_types" access="none"/>
-      </typeLevelAccessControl>
-    </role>
     <role code="Anthrop_Catalogue">
       <name>CMIS Anthropology Catalogue</name>
       <description>Members of this group have limited access to Anthropology data</description>
@@ -29732,6 +28478,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="none"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="none"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="none"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="none"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="none"/>
         <permission table="ca_objects" bundle="idno" access="none"/>
@@ -29847,6 +28594,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="none"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="none"/>
         <permission table="ca_entities" bundle="idno" access="none"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="none"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="none"/>
         <permission table="ca_entities" bundle="lifespan" access="none"/>
@@ -29926,6 +28674,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="none"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="none"/>
@@ -29948,6 +28697,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="none"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="none"/>
@@ -29956,6 +28712,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="none"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="none"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="none"/>
@@ -30418,7 +29175,134 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
     <role code="Anthrop_Curate">
       <name>CMIS Anthropology Curate</name>
       <description>Members of this group have full access to Anthropology data</description>
-      <actions/>
+      <actions>
+        <action>can_quicksearch</action>
+        <action>can_batch_import_media</action>
+        <action>can_batch_import_metadata</action>
+        <action>can_batch_export_metadata</action>
+        <action>can_set_preferences</action>
+        <action>can_create_adv_search_forms</action>
+        <action>can_edit_adv_search_forms</action>
+        <action>can_delete_adv_search_forms</action>
+        <action>can_use_adv_search_forms</action>
+        <action>can_create_ca_bundle_displays</action>
+        <action>can_edit_ca_bundle_displays</action>
+        <action>can_delete_ca_bundle_displays</action>
+        <action>can_use_ca_bundle_displays</action>
+        <action>can_duplicate_ca_bundle_displays</action>
+        <action>can_create_user_groups</action>
+        <action>can_create_sets</action>
+        <action>can_edit_sets</action>
+        <action>can_delete_sets</action>
+        <action>can_delete_own_sets</action>
+        <action>can_view_sets</action>
+        <action>can_duplicate_ca_sets</action>
+        <action>can_manage_user_comments</action>
+        <action>can_manage_user_tags</action>
+        <action>can_create_ca_objects</action>
+        <action>can_edit_ca_objects</action>
+        <action>can_search_ca_objects</action>
+        <action>can_browse_ca_objects</action>
+        <action>can_download_ca_object_representations</action>
+        <action>can_duplicate_ca_objects</action>
+        <action>can_quickadd_ca_objects</action>
+        <action>can_export_ca_objects</action>
+        <action>can_change_type_ca_objects</action>
+        <action>can_change_acl_ca_objects</action>
+        <action>can_batch_edit_ca_objects</action>
+        <action>can_batch_delete_ca_objects</action>
+        <action>can_see_current_location_in_inspector_ca_objects</action>
+        <action>can_create_ca_object_representations</action>
+        <action>can_edit_ca_object_representations</action>
+        <action>can_delete_ca_object_representations</action>
+        <action>can_search_ca_object_representations</action>
+        <action>can_browse_ca_object_representations</action>
+        <action>can_duplicate_ca_object_representations</action>
+        <action>can_export_ca_object_representations</action>
+        <action>can_change_type_ca_object_representations</action>
+        <action>can_change_acl_ca_object_representations</action>
+        <action>can_batch_edit_ca_object_representations</action>
+        <action>can_batch_delete_ca_object_representations</action>
+        <action>can_create_ca_representation_annotations</action>
+        <action>can_edit_ca_representation_annotations</action>
+        <action>can_delete_ca_representation_annotations</action>
+        <action>can_search_ca_representation_annotations</action>
+        <action>can_browse_ca_representation_annotations</action>
+        <action>can_duplicate_ca_representation_annotations</action>
+        <action>can_change_acl_ca_representation_annotations</action>
+        <action>can_create_ca_entities</action>
+        <action>can_edit_ca_entities</action>
+        <action>can_delete_ca_entities</action>
+        <action>can_search_ca_entities</action>
+        <action>can_browse_ca_entities</action>
+        <action>can_duplicate_ca_entities</action>
+        <action>can_export_ca_entities</action>
+        <action>can_quickadd_ca_entities</action>
+        <action>can_change_type_ca_entities</action>
+        <action>can_change_acl_ca_entities</action>
+        <action>can_batch_edit_ca_entities</action>
+        <action>can_batch_delete_ca_entities</action>
+        <action>can_create_ca_places</action>
+        <action>can_edit_ca_places</action>
+        <action>can_delete_ca_places</action>
+        <action>can_search_ca_places</action>
+        <action>can_browse_ca_places</action>
+        <action>can_duplicate_ca_places</action>
+        <action>can_export_ca_places</action>
+        <action>can_quickadd_ca_places</action>
+        <action>can_change_type_ca_places</action>
+        <action>can_change_acl_ca_places</action>
+        <action>can_batch_edit_ca_places</action>
+        <action>can_batch_delete_ca_places</action>
+        <action>can_create_ca_occurrences</action>
+        <action>can_edit_ca_occurrences</action>
+        <action>can_delete_ca_occurrences</action>
+        <action>can_search_ca_occurrences</action>
+        <action>can_browse_ca_occurrences</action>
+        <action>can_duplicate_ca_occurrences</action>
+        <action>can_export_ca_occurrences</action>
+        <action>can_quickadd_ca_occurrences</action>
+        <action>can_change_type_ca_occurrences</action>
+        <action>can_change_acl_ca_occurrences</action>
+        <action>can_batch_edit_ca_occurrences</action>
+        <action>can_batch_delete_ca_occurrences</action>
+        <action>can_create_ca_storage_locations</action>
+        <action>can_edit_ca_storage_locations</action>
+        <action>can_delete_ca_storage_locations</action>
+        <action>can_search_ca_storage_locations</action>
+        <action>can_browse_ca_storage_locations</action>
+        <action>can_duplicate_ca_storage_locations</action>
+        <action>can_export_ca_storage_locations</action>
+        <action>can_quickadd_ca_storage_locations</action>
+        <action>can_change_type_ca_storage_locations</action>
+        <action>can_change_acl_ca_storage_locations</action>
+        <action>can_batch_edit_ca_storage_locations</action>
+        <action>can_batch_delete_ca_storage_locations</action>
+        <action>can_create_ca_loans</action>
+        <action>can_edit_ca_loans</action>
+        <action>can_delete_ca_loans</action>
+        <action>can_search_ca_loans</action>
+        <action>can_browse_ca_loans</action>
+        <action>can_duplicate_ca_loans</action>
+        <action>can_export_ca_loans</action>
+        <action>can_quickadd_ca_loans</action>
+        <action>can_change_type_ca_loans</action>
+        <action>can_change_acl_ca_loans</action>
+        <action>can_batch_edit_ca_loans</action>
+        <action>can_batch_delete_ca_loans</action>
+        <action>can_create_ca_movements</action>
+        <action>can_edit_ca_movements</action>
+        <action>can_delete_ca_movements</action>
+        <action>can_search_ca_movements</action>
+        <action>can_browse_ca_movements</action>
+        <action>can_duplicate_ca_movements</action>
+        <action>can_export_ca_movements</action>
+        <action>can_quickadd_ca_movements</action>
+        <action>can_change_type_ca_movements</action>
+        <action>can_change_acl_ca_movements</action>
+        <action>can_batch_edit_ca_movements</action>
+        <action>can_batch_delete_ca_movements</action>
+      </actions>
       <bundleLevelAccessControl>
         <permission table="ca_objects" bundle="ca_attribute_GeologicalContext" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_SizeOrDuration" access="edit"/>
@@ -30487,6 +29371,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -30602,6 +29487,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -30681,6 +29567,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -30703,6 +29590,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -30711,6 +29605,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -31051,29 +29946,29 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
       </bundleLevelAccessControl>
       <typeLevelAccessControl>
         <permission table="ca_objects" type="anthropology" access="edit"/>
-        <permission table="ca_objects" type="az" access="edit"/>
-        <permission table="ca_objects" type="arachnid_myriapod" access="edit"/>
-        <permission table="ca_objects" type="crustacea" access="edit"/>
+        <permission table="ca_objects" type="az" access="none"/>
+        <permission table="ca_objects" type="arachnid_myriapod" access="none"/>
+        <permission table="ca_objects" type="crustacea" access="none"/>
         <permission table="ca_objects" type="DublinCore" access="edit"/>
-        <permission table="ca_objects" type="insect" access="edit"/>
-        <permission table="ca_objects" type="eps" access="edit"/>
-        <permission table="ca_objects" type="fish" access="edit"/>
-        <permission table="ca_objects" type="history" access="edit"/>
-        <permission table="ca_objects" type="early_childhood" access="edit"/>
-        <permission table="ca_objects" type="invertebrate_palaeontology" access="edit"/>
-        <permission table="ca_objects" type="mammal" access="edit"/>
-        <permission table="ca_objects" type="mineral" access="edit"/>
-        <permission table="ca_objects" type="mineral_mdc" access="edit"/>
-        <permission table="ca_objects" type="mineral_simpson" access="edit"/>
-        <permission table="ca_objects" type="miz" access="edit"/>
-        <permission table="ca_objects" type="mollusc" access="edit"/>
-        <permission table="ca_objects" type="DarwinCore" access="edit"/>
-        <permission table="ca_objects" type="bird" access="edit"/>
-        <permission table="ca_objects" type="reptile" access="edit"/>
+        <permission table="ca_objects" type="insect" access="none"/>
+        <permission table="ca_objects" type="eps" access="none"/>
+        <permission table="ca_objects" type="fish" access="none"/>
+        <permission table="ca_objects" type="history" access="none"/>
+        <permission table="ca_objects" type="early_childhood" access="none"/>
+        <permission table="ca_objects" type="invertebrate_palaeontology" access="none"/>
+        <permission table="ca_objects" type="mammal" access="none"/>
+        <permission table="ca_objects" type="mineral" access="none"/>
+        <permission table="ca_objects" type="mineral_mdc" access="none"/>
+        <permission table="ca_objects" type="mineral_simpson" access="none"/>
+        <permission table="ca_objects" type="miz" access="none"/>
+        <permission table="ca_objects" type="mollusc" access="none"/>
+        <permission table="ca_objects" type="DarwinCore" access="none"/>
+        <permission table="ca_objects" type="bird" access="none"/>
+        <permission table="ca_objects" type="reptile" access="none"/>
         <permission table="ca_objects" type="Root node for object_types" access="none"/>
-        <permission table="ca_objects" type="tz" access="edit"/>
-        <permission table="ca_objects" type="vertebrate_palaeontology" access="edit"/>
-        <permission table="ca_objects" type="worm" access="edit"/>
+        <permission table="ca_objects" type="tz" access="none"/>
+        <permission table="ca_objects" type="vertebrate_palaeontology" access="none"/>
+        <permission table="ca_objects" type="worm" access="none"/>
         <permission table="ca_object_lots" type="bequest" access="edit"/>
         <permission table="ca_object_lots" type="gift" access="edit"/>
         <permission table="ca_object_lots" type="loan" access="edit"/>
@@ -31110,8 +30005,8 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" type="anthropology_register" access="edit"/>
         <permission table="ca_occurrences" type="resource" access="edit"/>
         <permission table="ca_occurrences" type="Root node for occurrence_types" access="none"/>
-        <permission table="ca_collections" type="external" access="edit"/>
-        <permission table="ca_collections" type="internal" access="edit"/>
+        <permission table="ca_collections" type="external" access="none"/>
+        <permission table="ca_collections" type="internal" access="none"/>
         <permission table="ca_collections" type="Root node for collection_types" access="none"/>
         <permission table="ca_storage_locations" type="building" access="edit"/>
         <permission table="ca_storage_locations" type="cabinet" access="edit"/>
@@ -31242,6 +30137,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -31357,6 +30253,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -31436,6 +30333,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -31458,6 +30356,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -31466,6 +30371,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -31928,7 +30834,9 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
     <role code="Arachn_Catalogue">
       <name>CMIS Arachnology Catalogue </name>
       <description>Members of this group have limited access to Arachnology data</description>
-      <actions/>
+      <actions>
+        <action>can_quicksearch</action>
+      </actions>
       <bundleLevelAccessControl>
         <permission table="ca_objects" bundle="ca_attribute_GeologicalContext" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_SizeOrDuration" access="edit"/>
@@ -31997,6 +30905,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -32112,6 +31021,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -32191,6 +31101,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -32213,6 +31124,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -32221,6 +31139,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -32752,6 +31671,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -32867,6 +31787,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -32946,6 +31867,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -32968,6 +31890,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -32976,6 +31905,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -33507,6 +32437,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -33622,6 +32553,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -33701,6 +32633,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -33723,6 +32656,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -33731,6 +32671,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -34262,6 +33203,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -34377,6 +33319,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -34456,6 +33399,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -34478,6 +33422,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -34486,6 +33437,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -35017,6 +33969,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -35132,6 +34085,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -35211,6 +34165,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -35233,6 +34188,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -35241,6 +34203,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -35647,56 +34610,56 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_storage_locations" type="cabinet" access="edit"/>
         <permission table="ca_storage_locations" type="column" access="edit"/>
         <permission table="ca_storage_locations" type="drawer" access="edit"/>
-        <permission table="ca_storage_locations" type="drum" access="edit"/>
+        <permission table="ca_storage_locations" type="drum" access="none"/>
         <permission table="ca_storage_locations" type="floor" access="edit"/>
-        <permission table="ca_storage_locations" type="pallet" access="edit"/>
+        <permission table="ca_storage_locations" type="pallet" access="none"/>
         <permission table="ca_storage_locations" type="room" access="edit"/>
         <permission table="ca_storage_locations" type="Root node for storage_location_types" access="none"/>
         <permission table="ca_storage_locations" type="row" access="edit"/>
         <permission table="ca_storage_locations" type="shelf" access="edit"/>
         <permission table="ca_storage_locations" type="site" access="edit"/>
-        <permission table="ca_loans" type="custodial" access="edit"/>
-        <permission table="ca_loans" type="in" access="edit"/>
-        <permission table="ca_loans" type="out" access="edit"/>
+        <permission table="ca_loans" type="custodial" access="none"/>
+        <permission table="ca_loans" type="in" access="none"/>
+        <permission table="ca_loans" type="out" access="none"/>
         <permission table="ca_loans" type="Root node for loan_types" access="none"/>
-        <permission table="ca_movements" type="movement" access="edit"/>
+        <permission table="ca_movements" type="movement" access="none"/>
         <permission table="ca_movements" type="Root node for movement_types" access="none"/>
-        <permission table="ca_object_representations" type="back" access="edit"/>
-        <permission table="ca_object_representations" type="front" access="edit"/>
+        <permission table="ca_object_representations" type="back" access="none"/>
+        <permission table="ca_object_representations" type="front" access="none"/>
         <permission table="ca_object_representations" type="Root node for object_representation_types" access="none"/>
-        <permission table="ca_sets" type="public_presentation" access="edit"/>
+        <permission table="ca_sets" type="public_presentation" access="none"/>
         <permission table="ca_sets" type="Root node for set_types" access="none"/>
-        <permission table="ca_sets" type="user" access="edit"/>
-        <permission table="ca_set_items" type="public_presentation" access="edit"/>
+        <permission table="ca_sets" type="user" access="none"/>
+        <permission table="ca_set_items" type="public_presentation" access="none"/>
         <permission table="ca_set_items" type="Root node for set_types" access="none"/>
-        <permission table="ca_set_items" type="user" access="edit"/>
-        <permission table="ca_list_items" type="class" access="edit"/>
-        <permission table="ca_list_items" type="cohort" access="edit"/>
-        <permission table="ca_list_items" type="concept" access="edit"/>
-        <permission table="ca_list_items" type="family" access="edit"/>
-        <permission table="ca_list_items" type="genus" access="edit"/>
-        <permission table="ca_list_items" type="infraorder" access="edit"/>
-        <permission table="ca_list_items" type="kingdom" access="edit"/>
-        <permission table="ca_list_items" type="mineral" access="edit"/>
-        <permission table="ca_list_items" type="order" access="edit"/>
-        <permission table="ca_list_items" type="phylum" access="edit"/>
+        <permission table="ca_set_items" type="user" access="none"/>
+        <permission table="ca_list_items" type="class" access="none"/>
+        <permission table="ca_list_items" type="cohort" access="none"/>
+        <permission table="ca_list_items" type="concept" access="none"/>
+        <permission table="ca_list_items" type="family" access="none"/>
+        <permission table="ca_list_items" type="genus" access="none"/>
+        <permission table="ca_list_items" type="infraorder" access="none"/>
+        <permission table="ca_list_items" type="kingdom" access="none"/>
+        <permission table="ca_list_items" type="mineral" access="none"/>
+        <permission table="ca_list_items" type="order" access="none"/>
+        <permission table="ca_list_items" type="phylum" access="none"/>
         <permission table="ca_list_items" type="Root node for list_item_types" access="none"/>
-        <permission table="ca_list_items" type="scientific_name" access="edit"/>
-        <permission table="ca_list_items" type="species" access="edit"/>
-        <permission table="ca_list_items" type="subclass" access="edit"/>
-        <permission table="ca_list_items" type="subfamily" access="edit"/>
-        <permission table="ca_list_items" type="subgenus" access="edit"/>
-        <permission table="ca_list_items" type="suborder" access="edit"/>
-        <permission table="ca_list_items" type="subphylum" access="edit"/>
-        <permission table="ca_list_items" type="subspecies" access="edit"/>
-        <permission table="ca_list_items" type="superfamily" access="edit"/>
-        <permission table="ca_list_items" type="superorder" access="edit"/>
-        <permission table="ca_list_items" type="tribe" access="edit"/>
-        <permission table="ca_tours" type="full_length" access="edit"/>
+        <permission table="ca_list_items" type="scientific_name" access="none"/>
+        <permission table="ca_list_items" type="species" access="none"/>
+        <permission table="ca_list_items" type="subclass" access="none"/>
+        <permission table="ca_list_items" type="subfamily" access="none"/>
+        <permission table="ca_list_items" type="subgenus" access="none"/>
+        <permission table="ca_list_items" type="suborder" access="none"/>
+        <permission table="ca_list_items" type="subphylum" access="none"/>
+        <permission table="ca_list_items" type="subspecies" access="none"/>
+        <permission table="ca_list_items" type="superfamily" access="none"/>
+        <permission table="ca_list_items" type="superorder" access="none"/>
+        <permission table="ca_list_items" type="tribe" access="none"/>
+        <permission table="ca_tours" type="full_length" access="none"/>
         <permission table="ca_tours" type="Root node for tour_types" access="none"/>
-        <permission table="ca_tours" type="short" access="edit"/>
-        <permission table="ca_tour_stops" type="secondary" access="edit"/>
-        <permission table="ca_tour_stops" type="primary" access="edit"/>
+        <permission table="ca_tours" type="short" access="none"/>
+        <permission table="ca_tour_stops" type="secondary" access="none"/>
+        <permission table="ca_tour_stops" type="primary" access="none"/>
         <permission table="ca_tour_stops" type="Root node for tour_stop_types" access="none"/>
       </typeLevelAccessControl>
     </role>
@@ -35772,6 +34735,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -35887,6 +34851,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -35966,6 +34931,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -35988,6 +34954,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -35996,6 +34969,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -36527,6 +35501,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -36642,6 +35617,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -36721,6 +35697,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -36743,6 +35720,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -36751,6 +35735,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -37177,36 +36162,36 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_sets" type="public_presentation" access="edit"/>
         <permission table="ca_sets" type="Root node for set_types" access="none"/>
         <permission table="ca_sets" type="user" access="edit"/>
-        <permission table="ca_set_items" type="public_presentation" access="edit"/>
+        <permission table="ca_set_items" type="public_presentation" access="none"/>
         <permission table="ca_set_items" type="Root node for set_types" access="none"/>
-        <permission table="ca_set_items" type="user" access="edit"/>
-        <permission table="ca_list_items" type="class" access="edit"/>
-        <permission table="ca_list_items" type="cohort" access="edit"/>
-        <permission table="ca_list_items" type="concept" access="edit"/>
-        <permission table="ca_list_items" type="family" access="edit"/>
-        <permission table="ca_list_items" type="genus" access="edit"/>
-        <permission table="ca_list_items" type="infraorder" access="edit"/>
-        <permission table="ca_list_items" type="kingdom" access="edit"/>
-        <permission table="ca_list_items" type="mineral" access="edit"/>
-        <permission table="ca_list_items" type="order" access="edit"/>
-        <permission table="ca_list_items" type="phylum" access="edit"/>
+        <permission table="ca_set_items" type="user" access="none"/>
+        <permission table="ca_list_items" type="class" access="none"/>
+        <permission table="ca_list_items" type="cohort" access="none"/>
+        <permission table="ca_list_items" type="concept" access="none"/>
+        <permission table="ca_list_items" type="family" access="none"/>
+        <permission table="ca_list_items" type="genus" access="none"/>
+        <permission table="ca_list_items" type="infraorder" access="none"/>
+        <permission table="ca_list_items" type="kingdom" access="none"/>
+        <permission table="ca_list_items" type="mineral" access="none"/>
+        <permission table="ca_list_items" type="order" access="none"/>
+        <permission table="ca_list_items" type="phylum" access="none"/>
         <permission table="ca_list_items" type="Root node for list_item_types" access="none"/>
-        <permission table="ca_list_items" type="scientific_name" access="edit"/>
-        <permission table="ca_list_items" type="species" access="edit"/>
-        <permission table="ca_list_items" type="subclass" access="edit"/>
-        <permission table="ca_list_items" type="subfamily" access="edit"/>
-        <permission table="ca_list_items" type="subgenus" access="edit"/>
-        <permission table="ca_list_items" type="suborder" access="edit"/>
-        <permission table="ca_list_items" type="subphylum" access="edit"/>
-        <permission table="ca_list_items" type="subspecies" access="edit"/>
-        <permission table="ca_list_items" type="superfamily" access="edit"/>
-        <permission table="ca_list_items" type="superorder" access="edit"/>
-        <permission table="ca_list_items" type="tribe" access="edit"/>
-        <permission table="ca_tours" type="full_length" access="edit"/>
+        <permission table="ca_list_items" type="scientific_name" access="none"/>
+        <permission table="ca_list_items" type="species" access="none"/>
+        <permission table="ca_list_items" type="subclass" access="none"/>
+        <permission table="ca_list_items" type="subfamily" access="none"/>
+        <permission table="ca_list_items" type="subgenus" access="none"/>
+        <permission table="ca_list_items" type="suborder" access="none"/>
+        <permission table="ca_list_items" type="subphylum" access="none"/>
+        <permission table="ca_list_items" type="subspecies" access="none"/>
+        <permission table="ca_list_items" type="superfamily" access="none"/>
+        <permission table="ca_list_items" type="superorder" access="none"/>
+        <permission table="ca_list_items" type="tribe" access="none"/>
+        <permission table="ca_tours" type="full_length" access="none"/>
         <permission table="ca_tours" type="Root node for tour_types" access="none"/>
-        <permission table="ca_tours" type="short" access="edit"/>
-        <permission table="ca_tour_stops" type="secondary" access="edit"/>
-        <permission table="ca_tour_stops" type="primary" access="edit"/>
+        <permission table="ca_tours" type="short" access="none"/>
+        <permission table="ca_tour_stops" type="secondary" access="none"/>
+        <permission table="ca_tour_stops" type="primary" access="none"/>
         <permission table="ca_tour_stops" type="Root node for tour_stop_types" access="none"/>
       </typeLevelAccessControl>
     </role>
@@ -37282,6 +36267,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -37397,6 +36383,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -37476,6 +36463,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -37498,6 +36486,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -37506,6 +36501,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -37724,244 +36720,244 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_object_representations" bundle="idno" access="edit"/>
         <permission table="ca_object_representations" bundle="locale_id" access="edit"/>
         <permission table="ca_object_representations" bundle="md5" access="edit"/>
-        <permission table="ca_object_representations" bundle="media" access="edit"/>
-        <permission table="ca_object_representations" bundle="nonpreferred_labels" access="edit"/>
-        <permission table="ca_object_representations" bundle="original_filename" access="edit"/>
-        <permission table="ca_object_representations" bundle="preferred_labels" access="edit"/>
-        <permission table="ca_object_representations" bundle="rank" access="edit"/>
-        <permission table="ca_object_representations" bundle="representation_id" access="edit"/>
-        <permission table="ca_object_representations" bundle="source_id" access="edit"/>
-        <permission table="ca_object_representations" bundle="status" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="access" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="annotation_id" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="ca_entities" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="ca_list_items" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="ca_objects" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="ca_occurrences" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="ca_places" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="ca_representation_annotation_properties" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="ca_attribute_caption" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="locale_id" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="nonpreferred_labels" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="preferred_labels" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="preview" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="status" access="edit"/>
-        <permission table="ca_representation_annotations" bundle="user_id" access="edit"/>
-        <permission table="ca_sets" bundle="access" access="edit"/>
-        <permission table="ca_sets" bundle="ca_set_items" access="edit"/>
-        <permission table="ca_sets" bundle="ca_user_groups" access="edit"/>
-        <permission table="ca_sets" bundle="ca_users" access="edit"/>
-        <permission table="ca_sets" bundle="nonpreferred_labels" access="edit"/>
-        <permission table="ca_sets" bundle="preferred_labels" access="edit"/>
-        <permission table="ca_sets" bundle="rank" access="edit"/>
-        <permission table="ca_sets" bundle="ca_attribute_set_chron_date_element_code" access="edit"/>
-        <permission table="ca_sets" bundle="set_code" access="edit"/>
-        <permission table="ca_sets" bundle="ca_attribute_set_description" access="edit"/>
-        <permission table="ca_sets" bundle="set_id" access="edit"/>
-        <permission table="ca_sets" bundle="ca_attribute_set_presentation_type" access="edit"/>
-        <permission table="ca_sets" bundle="status" access="edit"/>
-        <permission table="ca_set_items" bundle="ca_attribute_caption" access="edit"/>
-        <permission table="ca_set_items" bundle="item_id" access="edit"/>
-        <permission table="ca_set_items" bundle="nonpreferred_labels" access="edit"/>
-        <permission table="ca_set_items" bundle="preferred_labels" access="edit"/>
-        <permission table="ca_set_items" bundle="row_id" access="edit"/>
-        <permission table="ca_set_items" bundle="ca_attribute_set_item_description" access="edit"/>
-        <permission table="ca_set_items" bundle="ca_attribute_set_item_is_primary" access="edit"/>
-        <permission table="ca_set_items" bundle="table_num" access="edit"/>
-        <permission table="ca_lists" bundle="default_sort" access="edit"/>
-        <permission table="ca_lists" bundle="is_hierarchical" access="edit"/>
-        <permission table="ca_lists" bundle="is_system_list" access="edit"/>
-        <permission table="ca_lists" bundle="list_code" access="edit"/>
-        <permission table="ca_lists" bundle="list_id" access="edit"/>
-        <permission table="ca_lists" bundle="nonpreferred_labels" access="edit"/>
-        <permission table="ca_lists" bundle="preferred_labels" access="edit"/>
-        <permission table="ca_lists" bundle="use_as_vocabulary" access="edit"/>
-        <permission table="ca_list_items" bundle="access" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_collections" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_entities" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_list_items" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_loans" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_movements" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_object_lots" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_object_representations" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_objects" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_occurrences" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_places" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_storage_locations" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_attribute_caabFamilyNo" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_attribute_chemical_formula" access="edit"/>
-        <permission table="ca_list_items" bundle="color" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_attribute_element" access="edit"/>
-        <permission table="ca_list_items" bundle="hierarchy_location" access="edit"/>
-        <permission table="ca_list_items" bundle="hierarchy_navigation" access="edit"/>
-        <permission table="ca_list_items" bundle="icon" access="edit"/>
-        <permission table="ca_list_items" bundle="idno" access="edit"/>
-        <permission table="ca_list_items" bundle="is_default" access="edit"/>
-        <permission table="ca_list_items" bundle="is_enabled" access="edit"/>
-        <permission table="ca_list_items" bundle="item_id" access="edit"/>
-        <permission table="ca_list_items" bundle="item_value" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_attribute_namePublishedInYear" access="edit"/>
-        <permission table="ca_list_items" bundle="nonpreferred_labels" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_attribute_parentheticalAuthor" access="edit"/>
-        <permission table="ca_list_items" bundle="preferred_labels" access="edit"/>
-        <permission table="ca_list_items" bundle="rank" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_attribute_scientificNameAuthorship" access="edit"/>
-        <permission table="ca_list_items" bundle="settings" access="edit"/>
-        <permission table="ca_list_items" bundle="source_id" access="edit"/>
-        <permission table="ca_list_items" bundle="status" access="edit"/>
-        <permission table="ca_list_items" bundle="ca_attribute_taxonRank" access="edit"/>
-        <permission table="ca_tours" bundle="access" access="edit"/>
-        <permission table="ca_tours" bundle="ca_tour_stops_list" access="edit"/>
-        <permission table="ca_tours" bundle="color" access="edit"/>
-        <permission table="ca_tours" bundle="icon" access="edit"/>
-        <permission table="ca_tours" bundle="nonpreferred_labels" access="edit"/>
-        <permission table="ca_tours" bundle="preferred_labels" access="edit"/>
-        <permission table="ca_tours" bundle="rank" access="edit"/>
-        <permission table="ca_tours" bundle="source_id" access="edit"/>
-        <permission table="ca_tours" bundle="status" access="edit"/>
-        <permission table="ca_tours" bundle="tour_code" access="edit"/>
-        <permission table="ca_tours" bundle="ca_attribute_tour_description" access="edit"/>
-        <permission table="ca_tours" bundle="tour_id" access="edit"/>
-        <permission table="ca_tour_stops" bundle="access" access="edit"/>
-        <permission table="ca_tour_stops" bundle="ca_collections" access="edit"/>
-        <permission table="ca_tour_stops" bundle="ca_entities" access="edit"/>
-        <permission table="ca_tour_stops" bundle="ca_list_items" access="edit"/>
-        <permission table="ca_tour_stops" bundle="ca_objects" access="edit"/>
-        <permission table="ca_tour_stops" bundle="ca_occurrences" access="edit"/>
-        <permission table="ca_tour_stops" bundle="ca_places" access="edit"/>
-        <permission table="ca_tour_stops" bundle="ca_tour_stops" access="edit"/>
-        <permission table="ca_tour_stops" bundle="color" access="edit"/>
-        <permission table="ca_tour_stops" bundle="hierarchy_location" access="edit"/>
-        <permission table="ca_tour_stops" bundle="hierarchy_navigation" access="edit"/>
-        <permission table="ca_tour_stops" bundle="icon" access="edit"/>
-        <permission table="ca_tour_stops" bundle="idno" access="edit"/>
-        <permission table="ca_tour_stops" bundle="nonpreferred_labels" access="edit"/>
-        <permission table="ca_tour_stops" bundle="preferred_labels" access="edit"/>
-        <permission table="ca_tour_stops" bundle="rank" access="edit"/>
-        <permission table="ca_tour_stops" bundle="status" access="edit"/>
-        <permission table="ca_tour_stops" bundle="stop_id" access="edit"/>
-        <permission table="ca_tour_stops" bundle="tour_id" access="edit"/>
-        <permission table="ca_tour_stops" bundle="ca_attribute_tour_stop_description" access="edit"/>
-        <permission table="ca_tour_stops" bundle="ca_attribute_tour_stop_georeference" access="edit"/>
+        <permission table="ca_object_representations" bundle="media" access="none"/>
+        <permission table="ca_object_representations" bundle="nonpreferred_labels" access="none"/>
+        <permission table="ca_object_representations" bundle="original_filename" access="none"/>
+        <permission table="ca_object_representations" bundle="preferred_labels" access="none"/>
+        <permission table="ca_object_representations" bundle="rank" access="none"/>
+        <permission table="ca_object_representations" bundle="representation_id" access="none"/>
+        <permission table="ca_object_representations" bundle="source_id" access="none"/>
+        <permission table="ca_object_representations" bundle="status" access="none"/>
+        <permission table="ca_representation_annotations" bundle="access" access="none"/>
+        <permission table="ca_representation_annotations" bundle="annotation_id" access="none"/>
+        <permission table="ca_representation_annotations" bundle="ca_entities" access="none"/>
+        <permission table="ca_representation_annotations" bundle="ca_list_items" access="none"/>
+        <permission table="ca_representation_annotations" bundle="ca_objects" access="none"/>
+        <permission table="ca_representation_annotations" bundle="ca_occurrences" access="none"/>
+        <permission table="ca_representation_annotations" bundle="ca_places" access="none"/>
+        <permission table="ca_representation_annotations" bundle="ca_representation_annotation_properties" access="none"/>
+        <permission table="ca_representation_annotations" bundle="ca_attribute_caption" access="none"/>
+        <permission table="ca_representation_annotations" bundle="locale_id" access="none"/>
+        <permission table="ca_representation_annotations" bundle="nonpreferred_labels" access="none"/>
+        <permission table="ca_representation_annotations" bundle="preferred_labels" access="none"/>
+        <permission table="ca_representation_annotations" bundle="preview" access="none"/>
+        <permission table="ca_representation_annotations" bundle="status" access="none"/>
+        <permission table="ca_representation_annotations" bundle="user_id" access="none"/>
+        <permission table="ca_sets" bundle="access" access="none"/>
+        <permission table="ca_sets" bundle="ca_set_items" access="none"/>
+        <permission table="ca_sets" bundle="ca_user_groups" access="none"/>
+        <permission table="ca_sets" bundle="ca_users" access="none"/>
+        <permission table="ca_sets" bundle="nonpreferred_labels" access="none"/>
+        <permission table="ca_sets" bundle="preferred_labels" access="none"/>
+        <permission table="ca_sets" bundle="rank" access="none"/>
+        <permission table="ca_sets" bundle="ca_attribute_set_chron_date_element_code" access="none"/>
+        <permission table="ca_sets" bundle="set_code" access="none"/>
+        <permission table="ca_sets" bundle="ca_attribute_set_description" access="none"/>
+        <permission table="ca_sets" bundle="set_id" access="none"/>
+        <permission table="ca_sets" bundle="ca_attribute_set_presentation_type" access="none"/>
+        <permission table="ca_sets" bundle="status" access="none"/>
+        <permission table="ca_set_items" bundle="ca_attribute_caption" access="none"/>
+        <permission table="ca_set_items" bundle="item_id" access="none"/>
+        <permission table="ca_set_items" bundle="nonpreferred_labels" access="none"/>
+        <permission table="ca_set_items" bundle="preferred_labels" access="none"/>
+        <permission table="ca_set_items" bundle="row_id" access="none"/>
+        <permission table="ca_set_items" bundle="ca_attribute_set_item_description" access="none"/>
+        <permission table="ca_set_items" bundle="ca_attribute_set_item_is_primary" access="none"/>
+        <permission table="ca_set_items" bundle="table_num" access="none"/>
+        <permission table="ca_lists" bundle="default_sort" access="none"/>
+        <permission table="ca_lists" bundle="is_hierarchical" access="none"/>
+        <permission table="ca_lists" bundle="is_system_list" access="none"/>
+        <permission table="ca_lists" bundle="list_code" access="none"/>
+        <permission table="ca_lists" bundle="list_id" access="none"/>
+        <permission table="ca_lists" bundle="nonpreferred_labels" access="none"/>
+        <permission table="ca_lists" bundle="preferred_labels" access="none"/>
+        <permission table="ca_lists" bundle="use_as_vocabulary" access="none"/>
+        <permission table="ca_list_items" bundle="access" access="none"/>
+        <permission table="ca_list_items" bundle="ca_collections" access="none"/>
+        <permission table="ca_list_items" bundle="ca_entities" access="none"/>
+        <permission table="ca_list_items" bundle="ca_list_items" access="none"/>
+        <permission table="ca_list_items" bundle="ca_loans" access="none"/>
+        <permission table="ca_list_items" bundle="ca_movements" access="none"/>
+        <permission table="ca_list_items" bundle="ca_object_lots" access="none"/>
+        <permission table="ca_list_items" bundle="ca_object_representations" access="none"/>
+        <permission table="ca_list_items" bundle="ca_objects" access="none"/>
+        <permission table="ca_list_items" bundle="ca_occurrences" access="none"/>
+        <permission table="ca_list_items" bundle="ca_places" access="none"/>
+        <permission table="ca_list_items" bundle="ca_storage_locations" access="none"/>
+        <permission table="ca_list_items" bundle="ca_attribute_caabFamilyNo" access="none"/>
+        <permission table="ca_list_items" bundle="ca_attribute_chemical_formula" access="none"/>
+        <permission table="ca_list_items" bundle="color" access="none"/>
+        <permission table="ca_list_items" bundle="ca_attribute_element" access="none"/>
+        <permission table="ca_list_items" bundle="hierarchy_location" access="none"/>
+        <permission table="ca_list_items" bundle="hierarchy_navigation" access="none"/>
+        <permission table="ca_list_items" bundle="icon" access="none"/>
+        <permission table="ca_list_items" bundle="idno" access="none"/>
+        <permission table="ca_list_items" bundle="is_default" access="none"/>
+        <permission table="ca_list_items" bundle="is_enabled" access="none"/>
+        <permission table="ca_list_items" bundle="item_id" access="none"/>
+        <permission table="ca_list_items" bundle="item_value" access="none"/>
+        <permission table="ca_list_items" bundle="ca_attribute_namePublishedInYear" access="none"/>
+        <permission table="ca_list_items" bundle="nonpreferred_labels" access="none"/>
+        <permission table="ca_list_items" bundle="ca_attribute_parentheticalAuthor" access="none"/>
+        <permission table="ca_list_items" bundle="preferred_labels" access="none"/>
+        <permission table="ca_list_items" bundle="rank" access="none"/>
+        <permission table="ca_list_items" bundle="ca_attribute_scientificNameAuthorship" access="none"/>
+        <permission table="ca_list_items" bundle="settings" access="none"/>
+        <permission table="ca_list_items" bundle="source_id" access="none"/>
+        <permission table="ca_list_items" bundle="status" access="none"/>
+        <permission table="ca_list_items" bundle="ca_attribute_taxonRank" access="none"/>
+        <permission table="ca_tours" bundle="access" access="none"/>
+        <permission table="ca_tours" bundle="ca_tour_stops_list" access="none"/>
+        <permission table="ca_tours" bundle="color" access="none"/>
+        <permission table="ca_tours" bundle="icon" access="none"/>
+        <permission table="ca_tours" bundle="nonpreferred_labels" access="none"/>
+        <permission table="ca_tours" bundle="preferred_labels" access="none"/>
+        <permission table="ca_tours" bundle="rank" access="none"/>
+        <permission table="ca_tours" bundle="source_id" access="none"/>
+        <permission table="ca_tours" bundle="status" access="none"/>
+        <permission table="ca_tours" bundle="tour_code" access="none"/>
+        <permission table="ca_tours" bundle="ca_attribute_tour_description" access="none"/>
+        <permission table="ca_tours" bundle="tour_id" access="none"/>
+        <permission table="ca_tour_stops" bundle="access" access="none"/>
+        <permission table="ca_tour_stops" bundle="ca_collections" access="none"/>
+        <permission table="ca_tour_stops" bundle="ca_entities" access="none"/>
+        <permission table="ca_tour_stops" bundle="ca_list_items" access="none"/>
+        <permission table="ca_tour_stops" bundle="ca_objects" access="none"/>
+        <permission table="ca_tour_stops" bundle="ca_occurrences" access="none"/>
+        <permission table="ca_tour_stops" bundle="ca_places" access="none"/>
+        <permission table="ca_tour_stops" bundle="ca_tour_stops" access="none"/>
+        <permission table="ca_tour_stops" bundle="color" access="none"/>
+        <permission table="ca_tour_stops" bundle="hierarchy_location" access="none"/>
+        <permission table="ca_tour_stops" bundle="hierarchy_navigation" access="none"/>
+        <permission table="ca_tour_stops" bundle="icon" access="none"/>
+        <permission table="ca_tour_stops" bundle="idno" access="none"/>
+        <permission table="ca_tour_stops" bundle="nonpreferred_labels" access="none"/>
+        <permission table="ca_tour_stops" bundle="preferred_labels" access="none"/>
+        <permission table="ca_tour_stops" bundle="rank" access="none"/>
+        <permission table="ca_tour_stops" bundle="status" access="none"/>
+        <permission table="ca_tour_stops" bundle="stop_id" access="none"/>
+        <permission table="ca_tour_stops" bundle="tour_id" access="none"/>
+        <permission table="ca_tour_stops" bundle="ca_attribute_tour_stop_description" access="none"/>
+        <permission table="ca_tour_stops" bundle="ca_attribute_tour_stop_georeference" access="none"/>
       </bundleLevelAccessControl>
       <typeLevelAccessControl>
-        <permission table="ca_objects" type="anthropology" access="edit"/>
-        <permission table="ca_objects" type="az" access="edit"/>
-        <permission table="ca_objects" type="arachnid_myriapod" access="edit"/>
-        <permission table="ca_objects" type="crustacea" access="edit"/>
-        <permission table="ca_objects" type="DublinCore" access="edit"/>
-        <permission table="ca_objects" type="insect" access="edit"/>
-        <permission table="ca_objects" type="eps" access="edit"/>
-        <permission table="ca_objects" type="fish" access="edit"/>
-        <permission table="ca_objects" type="history" access="edit"/>
-        <permission table="ca_objects" type="early_childhood" access="edit"/>
-        <permission table="ca_objects" type="invertebrate_palaeontology" access="edit"/>
-        <permission table="ca_objects" type="mammal" access="edit"/>
-        <permission table="ca_objects" type="mineral" access="edit"/>
-        <permission table="ca_objects" type="mineral_mdc" access="edit"/>
-        <permission table="ca_objects" type="mineral_simpson" access="edit"/>
-        <permission table="ca_objects" type="miz" access="edit"/>
-        <permission table="ca_objects" type="mollusc" access="edit"/>
-        <permission table="ca_objects" type="DarwinCore" access="edit"/>
-        <permission table="ca_objects" type="bird" access="edit"/>
-        <permission table="ca_objects" type="reptile" access="edit"/>
+        <permission table="ca_objects" type="anthropology" access="none"/>
+        <permission table="ca_objects" type="az" access="none"/>
+        <permission table="ca_objects" type="arachnid_myriapod" access="none"/>
+        <permission table="ca_objects" type="crustacea" access="none"/>
+        <permission table="ca_objects" type="DublinCore" access="none"/>
+        <permission table="ca_objects" type="insect" access="none"/>
+        <permission table="ca_objects" type="eps" access="none"/>
+        <permission table="ca_objects" type="fish" access="none"/>
+        <permission table="ca_objects" type="history" access="none"/>
+        <permission table="ca_objects" type="early_childhood" access="none"/>
+        <permission table="ca_objects" type="invertebrate_palaeontology" access="none"/>
+        <permission table="ca_objects" type="mammal" access="none"/>
+        <permission table="ca_objects" type="mineral" access="none"/>
+        <permission table="ca_objects" type="mineral_mdc" access="none"/>
+        <permission table="ca_objects" type="mineral_simpson" access="none"/>
+        <permission table="ca_objects" type="miz" access="none"/>
+        <permission table="ca_objects" type="mollusc" access="none"/>
+        <permission table="ca_objects" type="DarwinCore" access="none"/>
+        <permission table="ca_objects" type="bird" access="none"/>
+        <permission table="ca_objects" type="reptile" access="none"/>
         <permission table="ca_objects" type="Root node for object_types" access="none"/>
-        <permission table="ca_objects" type="tz" access="edit"/>
-        <permission table="ca_objects" type="vertebrate_palaeontology" access="edit"/>
-        <permission table="ca_objects" type="worm" access="edit"/>
-        <permission table="ca_object_lots" type="bequest" access="edit"/>
-        <permission table="ca_object_lots" type="gift" access="edit"/>
-        <permission table="ca_object_lots" type="loan" access="edit"/>
-        <permission table="ca_object_lots" type="long_term_loan" access="edit"/>
-        <permission table="ca_object_lots" type="purchase" access="edit"/>
-        <permission table="ca_object_lots" type="restricted_gift" access="edit"/>
+        <permission table="ca_objects" type="tz" access="none"/>
+        <permission table="ca_objects" type="vertebrate_palaeontology" access="none"/>
+        <permission table="ca_objects" type="worm" access="none"/>
+        <permission table="ca_object_lots" type="bequest" access="none"/>
+        <permission table="ca_object_lots" type="gift" access="none"/>
+        <permission table="ca_object_lots" type="loan" access="none"/>
+        <permission table="ca_object_lots" type="long_term_loan" access="none"/>
+        <permission table="ca_object_lots" type="purchase" access="none"/>
+        <permission table="ca_object_lots" type="restricted_gift" access="none"/>
         <permission table="ca_object_lots" type="Root node for object_lot_types" access="none"/>
-        <permission table="ca_entities" type="ind" access="edit"/>
-        <permission table="ca_entities" type="org" access="edit"/>
+        <permission table="ca_entities" type="ind" access="none"/>
+        <permission table="ca_entities" type="org" access="none"/>
         <permission table="ca_entities" type="Root node for entity_types" access="none"/>
-        <permission table="ca_places" type="city" access="edit"/>
-        <permission table="ca_places" type="continent" access="edit"/>
-        <permission table="ca_places" type="country" access="edit"/>
-        <permission table="ca_places" type="cultural_area" access="edit"/>
-        <permission table="ca_places" type="islandGroup" access="edit"/>
-        <permission table="ca_places" type="island" access="edit"/>
-        <permission table="ca_places" type="location" access="edit"/>
-        <permission table="ca_places" type="neighborhood" access="edit"/>
-        <permission table="ca_places" type="other" access="edit"/>
-        <permission table="ca_places" type="region" access="edit"/>
-        <permission table="ca_places" type="river" access="edit"/>
+        <permission table="ca_places" type="city" access="none"/>
+        <permission table="ca_places" type="continent" access="none"/>
+        <permission table="ca_places" type="country" access="none"/>
+        <permission table="ca_places" type="cultural_area" access="none"/>
+        <permission table="ca_places" type="islandGroup" access="none"/>
+        <permission table="ca_places" type="island" access="none"/>
+        <permission table="ca_places" type="location" access="none"/>
+        <permission table="ca_places" type="neighborhood" access="none"/>
+        <permission table="ca_places" type="other" access="none"/>
+        <permission table="ca_places" type="region" access="none"/>
+        <permission table="ca_places" type="river" access="none"/>
         <permission table="ca_places" type="Root node for place_types" access="none"/>
-        <permission table="ca_places" type="site" access="edit"/>
-        <permission table="ca_places" type="state" access="edit"/>
-        <permission table="ca_places" type="waterBody" access="edit"/>
-        <permission table="ca_occurrences" type="conservation_analysis" access="edit"/>
-        <permission table="ca_occurrences" type="conservation_assignment" access="edit"/>
-        <permission table="ca_occurrences" type="collectingEvent" access="edit"/>
-        <permission table="ca_occurrences" type="conservation" access="edit"/>
-        <permission table="ca_occurrences" type="conservation_job" access="edit"/>
-        <permission table="ca_occurrences" type="conservation_report" access="edit"/>
-        <permission table="ca_occurrences" type="exhibition" access="edit"/>
-        <permission table="ca_occurrences" type="map" access="edit"/>
-        <permission table="ca_occurrences" type="anthropology_register" access="edit"/>
-        <permission table="ca_occurrences" type="resource" access="edit"/>
+        <permission table="ca_places" type="site" access="none"/>
+        <permission table="ca_places" type="state" access="none"/>
+        <permission table="ca_places" type="waterBody" access="none"/>
+        <permission table="ca_occurrences" type="conservation_analysis" access="none"/>
+        <permission table="ca_occurrences" type="conservation_assignment" access="none"/>
+        <permission table="ca_occurrences" type="collectingEvent" access="none"/>
+        <permission table="ca_occurrences" type="conservation" access="none"/>
+        <permission table="ca_occurrences" type="conservation_job" access="none"/>
+        <permission table="ca_occurrences" type="conservation_report" access="none"/>
+        <permission table="ca_occurrences" type="exhibition" access="none"/>
+        <permission table="ca_occurrences" type="map" access="none"/>
+        <permission table="ca_occurrences" type="anthropology_register" access="none"/>
+        <permission table="ca_occurrences" type="resource" access="none"/>
         <permission table="ca_occurrences" type="Root node for occurrence_types" access="none"/>
-        <permission table="ca_collections" type="external" access="edit"/>
-        <permission table="ca_collections" type="internal" access="edit"/>
+        <permission table="ca_collections" type="external" access="none"/>
+        <permission table="ca_collections" type="internal" access="none"/>
         <permission table="ca_collections" type="Root node for collection_types" access="none"/>
-        <permission table="ca_storage_locations" type="building" access="edit"/>
-        <permission table="ca_storage_locations" type="cabinet" access="edit"/>
-        <permission table="ca_storage_locations" type="column" access="edit"/>
-        <permission table="ca_storage_locations" type="drawer" access="edit"/>
-        <permission table="ca_storage_locations" type="drum" access="edit"/>
-        <permission table="ca_storage_locations" type="floor" access="edit"/>
-        <permission table="ca_storage_locations" type="pallet" access="edit"/>
-        <permission table="ca_storage_locations" type="room" access="edit"/>
+        <permission table="ca_storage_locations" type="building" access="none"/>
+        <permission table="ca_storage_locations" type="cabinet" access="none"/>
+        <permission table="ca_storage_locations" type="column" access="none"/>
+        <permission table="ca_storage_locations" type="drawer" access="none"/>
+        <permission table="ca_storage_locations" type="drum" access="none"/>
+        <permission table="ca_storage_locations" type="floor" access="none"/>
+        <permission table="ca_storage_locations" type="pallet" access="none"/>
+        <permission table="ca_storage_locations" type="room" access="none"/>
         <permission table="ca_storage_locations" type="Root node for storage_location_types" access="none"/>
-        <permission table="ca_storage_locations" type="row" access="edit"/>
-        <permission table="ca_storage_locations" type="shelf" access="edit"/>
-        <permission table="ca_storage_locations" type="site" access="edit"/>
-        <permission table="ca_loans" type="custodial" access="edit"/>
-        <permission table="ca_loans" type="in" access="edit"/>
-        <permission table="ca_loans" type="out" access="edit"/>
+        <permission table="ca_storage_locations" type="row" access="none"/>
+        <permission table="ca_storage_locations" type="shelf" access="none"/>
+        <permission table="ca_storage_locations" type="site" access="none"/>
+        <permission table="ca_loans" type="custodial" access="none"/>
+        <permission table="ca_loans" type="in" access="none"/>
+        <permission table="ca_loans" type="out" access="none"/>
         <permission table="ca_loans" type="Root node for loan_types" access="none"/>
-        <permission table="ca_movements" type="movement" access="edit"/>
+        <permission table="ca_movements" type="movement" access="none"/>
         <permission table="ca_movements" type="Root node for movement_types" access="none"/>
-        <permission table="ca_object_representations" type="back" access="edit"/>
-        <permission table="ca_object_representations" type="front" access="edit"/>
+        <permission table="ca_object_representations" type="back" access="none"/>
+        <permission table="ca_object_representations" type="front" access="none"/>
         <permission table="ca_object_representations" type="Root node for object_representation_types" access="none"/>
-        <permission table="ca_sets" type="public_presentation" access="edit"/>
+        <permission table="ca_sets" type="public_presentation" access="none"/>
         <permission table="ca_sets" type="Root node for set_types" access="none"/>
-        <permission table="ca_sets" type="user" access="edit"/>
-        <permission table="ca_set_items" type="public_presentation" access="edit"/>
+        <permission table="ca_sets" type="user" access="none"/>
+        <permission table="ca_set_items" type="public_presentation" access="none"/>
         <permission table="ca_set_items" type="Root node for set_types" access="none"/>
-        <permission table="ca_set_items" type="user" access="edit"/>
-        <permission table="ca_list_items" type="class" access="edit"/>
-        <permission table="ca_list_items" type="cohort" access="edit"/>
-        <permission table="ca_list_items" type="concept" access="edit"/>
-        <permission table="ca_list_items" type="family" access="edit"/>
-        <permission table="ca_list_items" type="genus" access="edit"/>
-        <permission table="ca_list_items" type="infraorder" access="edit"/>
-        <permission table="ca_list_items" type="kingdom" access="edit"/>
-        <permission table="ca_list_items" type="mineral" access="edit"/>
-        <permission table="ca_list_items" type="order" access="edit"/>
-        <permission table="ca_list_items" type="phylum" access="edit"/>
+        <permission table="ca_set_items" type="user" access="none"/>
+        <permission table="ca_list_items" type="class" access="none"/>
+        <permission table="ca_list_items" type="cohort" access="none"/>
+        <permission table="ca_list_items" type="concept" access="none"/>
+        <permission table="ca_list_items" type="family" access="none"/>
+        <permission table="ca_list_items" type="genus" access="none"/>
+        <permission table="ca_list_items" type="infraorder" access="none"/>
+        <permission table="ca_list_items" type="kingdom" access="none"/>
+        <permission table="ca_list_items" type="mineral" access="none"/>
+        <permission table="ca_list_items" type="order" access="none"/>
+        <permission table="ca_list_items" type="phylum" access="none"/>
         <permission table="ca_list_items" type="Root node for list_item_types" access="none"/>
-        <permission table="ca_list_items" type="scientific_name" access="edit"/>
-        <permission table="ca_list_items" type="species" access="edit"/>
-        <permission table="ca_list_items" type="subclass" access="edit"/>
-        <permission table="ca_list_items" type="subfamily" access="edit"/>
-        <permission table="ca_list_items" type="subgenus" access="edit"/>
-        <permission table="ca_list_items" type="suborder" access="edit"/>
-        <permission table="ca_list_items" type="subphylum" access="edit"/>
-        <permission table="ca_list_items" type="subspecies" access="edit"/>
-        <permission table="ca_list_items" type="superfamily" access="edit"/>
-        <permission table="ca_list_items" type="superorder" access="edit"/>
-        <permission table="ca_list_items" type="tribe" access="edit"/>
-        <permission table="ca_tours" type="full_length" access="edit"/>
+        <permission table="ca_list_items" type="scientific_name" access="none"/>
+        <permission table="ca_list_items" type="species" access="none"/>
+        <permission table="ca_list_items" type="subclass" access="none"/>
+        <permission table="ca_list_items" type="subfamily" access="none"/>
+        <permission table="ca_list_items" type="subgenus" access="none"/>
+        <permission table="ca_list_items" type="suborder" access="none"/>
+        <permission table="ca_list_items" type="subphylum" access="none"/>
+        <permission table="ca_list_items" type="subspecies" access="none"/>
+        <permission table="ca_list_items" type="superfamily" access="none"/>
+        <permission table="ca_list_items" type="superorder" access="none"/>
+        <permission table="ca_list_items" type="tribe" access="none"/>
+        <permission table="ca_tours" type="full_length" access="none"/>
         <permission table="ca_tours" type="Root node for tour_types" access="none"/>
-        <permission table="ca_tours" type="short" access="edit"/>
-        <permission table="ca_tour_stops" type="secondary" access="edit"/>
-        <permission table="ca_tour_stops" type="primary" access="edit"/>
+        <permission table="ca_tours" type="short" access="none"/>
+        <permission table="ca_tour_stops" type="secondary" access="none"/>
+        <permission table="ca_tour_stops" type="primary" access="none"/>
         <permission table="ca_tour_stops" type="Root node for tour_stop_types" access="none"/>
       </typeLevelAccessControl>
     </role>
@@ -38037,6 +37033,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -38152,6 +37149,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -38231,6 +37229,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -38253,6 +37252,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -38261,6 +37267,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -38792,6 +37799,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -38907,6 +37915,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -38986,6 +37995,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -39008,6 +38018,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -39016,6 +38033,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -39547,6 +38565,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -39662,6 +38681,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -39741,6 +38761,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -39763,6 +38784,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -39771,6 +38799,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -40302,6 +39331,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -40417,6 +39447,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -40496,6 +39527,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -40518,6 +39550,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -40526,6 +39565,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -41057,6 +40097,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -41172,6 +40213,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -41251,6 +40293,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -41273,6 +40316,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -41281,6 +40331,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -41812,6 +40863,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -41927,6 +40979,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -42006,6 +41059,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -42028,6 +41082,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -42036,6 +41097,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -42567,6 +41629,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -42682,6 +41745,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -42761,6 +41825,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -42783,6 +41848,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -42791,6 +41863,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -43322,6 +42395,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -43437,6 +42511,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -43516,6 +42591,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -43538,6 +42614,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -43546,6 +42629,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -44077,6 +43161,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -44192,6 +43277,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -44271,6 +43357,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -44293,6 +43380,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -44301,6 +43395,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -44832,6 +43927,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -44947,6 +44043,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -45026,6 +44123,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -45048,6 +44146,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -45056,6 +44161,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -45587,6 +44693,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -45702,6 +44809,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -45781,6 +44889,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -45803,6 +44912,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -45811,6 +44927,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -46342,6 +45459,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -46457,6 +45575,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -46536,6 +45655,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -46558,6 +45678,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -46566,6 +45693,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -47097,6 +46225,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -47212,6 +46341,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -47291,6 +46421,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -47313,6 +46444,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -47321,6 +46459,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -47852,6 +46991,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -47967,6 +47107,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -48046,6 +47187,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -48068,6 +47210,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -48076,6 +47225,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -48607,6 +47757,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -48722,6 +47873,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -48801,6 +47953,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -48823,6 +47976,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -48831,6 +47991,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -49362,6 +48523,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -49477,6 +48639,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -49556,6 +48719,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -49578,6 +48742,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -49586,6 +48757,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -50117,6 +49289,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -50232,6 +49405,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -50311,6 +49485,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -50333,6 +49508,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -50341,6 +49523,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -50872,6 +50055,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -50987,6 +50171,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -51066,6 +50251,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -51088,6 +50274,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -51096,6 +50289,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -51627,6 +50821,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -51742,6 +50937,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -51821,6 +51017,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -51843,6 +51040,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -51851,6 +51055,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -52382,6 +51587,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -52497,6 +51703,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -52576,6 +51783,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -52598,6 +51806,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -52606,6 +51821,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -53137,6 +52353,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -53252,6 +52469,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -53331,6 +52549,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -53353,6 +52572,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -53361,6 +52587,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -53823,7 +53050,124 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
     <role code="Palaeont_Curate">
       <name>CMIS Palaeontology Curate</name>
       <description>Members of this group have full access to Palaeontology data</description>
-      <actions/>
+      <actions>
+        <action>can_batch_export_metadata</action>
+        <action>can_set_preferences</action>
+        <action>can_create_adv_search_forms</action>
+        <action>can_edit_adv_search_forms</action>
+        <action>can_delete_adv_search_forms</action>
+        <action>can_use_adv_search_forms</action>
+        <action>can_create_ca_bundle_displays</action>
+        <action>can_edit_ca_bundle_displays</action>
+        <action>can_delete_ca_bundle_displays</action>
+        <action>can_use_ca_bundle_displays</action>
+        <action>can_duplicate_ca_bundle_displays</action>
+        <action>can_create_user_groups</action>
+        <action>can_create_sets</action>
+        <action>can_edit_sets</action>
+        <action>can_delete_sets</action>
+        <action>can_delete_own_sets</action>
+        <action>can_view_sets</action>
+        <action>can_duplicate_ca_sets</action>
+        <action>can_create_ca_objects</action>
+        <action>can_edit_ca_objects</action>
+        <action>can_search_ca_objects</action>
+        <action>can_browse_ca_objects</action>
+        <action>can_download_ca_object_representations</action>
+        <action>can_duplicate_ca_objects</action>
+        <action>can_quickadd_ca_objects</action>
+        <action>can_export_ca_objects</action>
+        <action>can_change_acl_ca_objects</action>
+        <action>can_batch_edit_ca_objects</action>
+        <action>can_batch_delete_ca_objects</action>
+        <action>can_see_current_location_in_inspector_ca_objects</action>
+        <action>can_create_ca_object_representations</action>
+        <action>can_edit_ca_object_representations</action>
+        <action>can_delete_ca_object_representations</action>
+        <action>can_search_ca_object_representations</action>
+        <action>can_browse_ca_object_representations</action>
+        <action>can_duplicate_ca_object_representations</action>
+        <action>can_export_ca_object_representations</action>
+        <action>can_change_type_ca_object_representations</action>
+        <action>can_change_acl_ca_object_representations</action>
+        <action>can_batch_edit_ca_object_representations</action>
+        <action>can_batch_delete_ca_object_representations</action>
+        <action>can_create_ca_representation_annotations</action>
+        <action>can_edit_ca_representation_annotations</action>
+        <action>can_delete_ca_representation_annotations</action>
+        <action>can_search_ca_representation_annotations</action>
+        <action>can_browse_ca_representation_annotations</action>
+        <action>can_duplicate_ca_representation_annotations</action>
+        <action>can_change_acl_ca_representation_annotations</action>
+        <action>can_create_ca_entities</action>
+        <action>can_edit_ca_entities</action>
+        <action>can_search_ca_entities</action>
+        <action>can_browse_ca_entities</action>
+        <action>can_duplicate_ca_entities</action>
+        <action>can_export_ca_entities</action>
+        <action>can_quickadd_ca_entities</action>
+        <action>can_change_type_ca_entities</action>
+        <action>can_change_acl_ca_entities</action>
+        <action>can_batch_edit_ca_entities</action>
+        <action>can_batch_delete_ca_entities</action>
+        <action>can_create_ca_places</action>
+        <action>can_edit_ca_places</action>
+        <action>can_search_ca_places</action>
+        <action>can_browse_ca_places</action>
+        <action>can_duplicate_ca_places</action>
+        <action>can_export_ca_places</action>
+        <action>can_quickadd_ca_places</action>
+        <action>can_change_type_ca_places</action>
+        <action>can_change_acl_ca_places</action>
+        <action>can_batch_edit_ca_places</action>
+        <action>can_batch_delete_ca_places</action>
+        <action>can_create_ca_occurrences</action>
+        <action>can_edit_ca_occurrences</action>
+        <action>can_search_ca_occurrences</action>
+        <action>can_browse_ca_occurrences</action>
+        <action>can_duplicate_ca_occurrences</action>
+        <action>can_export_ca_occurrences</action>
+        <action>can_quickadd_ca_occurrences</action>
+        <action>can_change_type_ca_occurrences</action>
+        <action>can_change_acl_ca_occurrences</action>
+        <action>can_batch_edit_ca_occurrences</action>
+        <action>can_batch_delete_ca_occurrences</action>
+        <action>can_create_ca_storage_locations</action>
+        <action>can_edit_ca_storage_locations</action>
+        <action>can_search_ca_storage_locations</action>
+        <action>can_browse_ca_storage_locations</action>
+        <action>can_duplicate_ca_storage_locations</action>
+        <action>can_export_ca_storage_locations</action>
+        <action>can_quickadd_ca_storage_locations</action>
+        <action>can_change_type_ca_storage_locations</action>
+        <action>can_change_acl_ca_storage_locations</action>
+        <action>can_batch_edit_ca_storage_locations</action>
+        <action>can_batch_delete_ca_storage_locations</action>
+        <action>can_create_ca_loans</action>
+        <action>can_edit_ca_loans</action>
+        <action>can_delete_ca_loans</action>
+        <action>can_search_ca_loans</action>
+        <action>can_browse_ca_loans</action>
+        <action>can_duplicate_ca_loans</action>
+        <action>can_export_ca_loans</action>
+        <action>can_quickadd_ca_loans</action>
+        <action>can_change_type_ca_loans</action>
+        <action>can_change_acl_ca_loans</action>
+        <action>can_batch_edit_ca_loans</action>
+        <action>can_batch_delete_ca_loans</action>
+        <action>can_create_ca_movements</action>
+        <action>can_edit_ca_movements</action>
+        <action>can_delete_ca_movements</action>
+        <action>can_search_ca_movements</action>
+        <action>can_browse_ca_movements</action>
+        <action>can_duplicate_ca_movements</action>
+        <action>can_export_ca_movements</action>
+        <action>can_quickadd_ca_movements</action>
+        <action>can_change_type_ca_movements</action>
+        <action>can_change_acl_ca_movements</action>
+        <action>can_batch_edit_ca_movements</action>
+        <action>can_batch_delete_ca_movements</action>
+      </actions>
       <bundleLevelAccessControl>
         <permission table="ca_objects" bundle="ca_attribute_GeologicalContext" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_SizeOrDuration" access="edit"/>
@@ -53892,6 +53236,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -54007,6 +53352,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -54086,6 +53432,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -54108,6 +53455,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -54116,6 +53470,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -54455,30 +53810,30 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_tour_stops" bundle="ca_attribute_tour_stop_georeference" access="edit"/>
       </bundleLevelAccessControl>
       <typeLevelAccessControl>
-        <permission table="ca_objects" type="anthropology" access="edit"/>
-        <permission table="ca_objects" type="az" access="edit"/>
-        <permission table="ca_objects" type="arachnid_myriapod" access="edit"/>
-        <permission table="ca_objects" type="crustacea" access="edit"/>
-        <permission table="ca_objects" type="DublinCore" access="edit"/>
-        <permission table="ca_objects" type="insect" access="edit"/>
+        <permission table="ca_objects" type="anthropology" access="none"/>
+        <permission table="ca_objects" type="az" access="none"/>
+        <permission table="ca_objects" type="arachnid_myriapod" access="none"/>
+        <permission table="ca_objects" type="crustacea" access="none"/>
+        <permission table="ca_objects" type="DublinCore" access="none"/>
+        <permission table="ca_objects" type="insect" access="none"/>
         <permission table="ca_objects" type="eps" access="edit"/>
-        <permission table="ca_objects" type="fish" access="edit"/>
-        <permission table="ca_objects" type="history" access="edit"/>
-        <permission table="ca_objects" type="early_childhood" access="edit"/>
+        <permission table="ca_objects" type="fish" access="none"/>
+        <permission table="ca_objects" type="history" access="none"/>
+        <permission table="ca_objects" type="early_childhood" access="none"/>
         <permission table="ca_objects" type="invertebrate_palaeontology" access="edit"/>
-        <permission table="ca_objects" type="mammal" access="edit"/>
-        <permission table="ca_objects" type="mineral" access="edit"/>
-        <permission table="ca_objects" type="mineral_mdc" access="edit"/>
-        <permission table="ca_objects" type="mineral_simpson" access="edit"/>
-        <permission table="ca_objects" type="miz" access="edit"/>
-        <permission table="ca_objects" type="mollusc" access="edit"/>
-        <permission table="ca_objects" type="DarwinCore" access="edit"/>
-        <permission table="ca_objects" type="bird" access="edit"/>
-        <permission table="ca_objects" type="reptile" access="edit"/>
+        <permission table="ca_objects" type="mammal" access="none"/>
+        <permission table="ca_objects" type="mineral" access="none"/>
+        <permission table="ca_objects" type="mineral_mdc" access="none"/>
+        <permission table="ca_objects" type="mineral_simpson" access="none"/>
+        <permission table="ca_objects" type="miz" access="none"/>
+        <permission table="ca_objects" type="mollusc" access="none"/>
+        <permission table="ca_objects" type="DarwinCore" access="none"/>
+        <permission table="ca_objects" type="bird" access="none"/>
+        <permission table="ca_objects" type="reptile" access="none"/>
         <permission table="ca_objects" type="Root node for object_types" access="none"/>
-        <permission table="ca_objects" type="tz" access="edit"/>
+        <permission table="ca_objects" type="tz" access="none"/>
         <permission table="ca_objects" type="vertebrate_palaeontology" access="edit"/>
-        <permission table="ca_objects" type="worm" access="edit"/>
+        <permission table="ca_objects" type="worm" access="none"/>
         <permission table="ca_object_lots" type="bequest" access="edit"/>
         <permission table="ca_object_lots" type="gift" access="edit"/>
         <permission table="ca_object_lots" type="loan" access="edit"/>
@@ -54515,8 +53870,8 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" type="anthropology_register" access="edit"/>
         <permission table="ca_occurrences" type="resource" access="edit"/>
         <permission table="ca_occurrences" type="Root node for occurrence_types" access="none"/>
-        <permission table="ca_collections" type="external" access="edit"/>
-        <permission table="ca_collections" type="internal" access="edit"/>
+        <permission table="ca_collections" type="external" access="none"/>
+        <permission table="ca_collections" type="internal" access="none"/>
         <permission table="ca_collections" type="Root node for collection_types" access="none"/>
         <permission table="ca_storage_locations" type="building" access="edit"/>
         <permission table="ca_storage_locations" type="cabinet" access="edit"/>
@@ -54647,6 +54002,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -54762,6 +54118,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -54841,6 +54198,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -54863,6 +54221,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -54871,6 +54236,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -55402,6 +54768,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -55517,6 +54884,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -55596,6 +54964,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -55618,6 +54987,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -55626,6 +55002,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -56157,6 +55534,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -56272,6 +55650,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -56351,6 +55730,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -56373,6 +55753,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -56381,6 +55768,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -56912,6 +56300,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -57027,6 +56416,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -57106,6 +56496,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -57128,6 +56519,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -57136,6 +56534,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -57667,6 +57066,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -57782,6 +57182,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -57861,6 +57262,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -57883,6 +57285,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -57891,6 +57300,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -58422,6 +57832,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -58537,6 +57948,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -58616,6 +58028,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -58638,6 +58051,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -58646,6 +58066,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -59177,6 +58598,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -59292,6 +58714,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -59371,6 +58794,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -59393,6 +58817,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -59401,6 +58832,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -59932,6 +59364,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -60047,6 +59480,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -60126,6 +59560,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -60148,6 +59583,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -60156,6 +59598,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -60687,6 +60130,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -60802,6 +60246,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -60881,6 +60326,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -60903,6 +60349,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -60911,6 +60364,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -61442,6 +60896,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -61557,6 +61012,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -61636,6 +61092,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -61658,6 +61115,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -61666,6 +61130,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -62197,6 +61662,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_objects" bundle="ca_attribute_habitat" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_objects" bundle="hierarchy_navigation" access="edit"/>
+        <permission table="ca_objects" bundle="ca_attribute_historyClassificationContainer" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_host_rock" access="edit"/>
         <permission table="ca_objects" bundle="ca_attribute_identifiedBy" access="edit"/>
         <permission table="ca_objects" bundle="idno" access="edit"/>
@@ -62312,6 +61778,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_entities" bundle="hierarchy_location" access="edit"/>
         <permission table="ca_entities" bundle="hierarchy_navigation" access="edit"/>
         <permission table="ca_entities" bundle="idno" access="edit"/>
+        <permission table="ca_entities" bundle="ca_attribute_internal" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_internal_notes" access="edit"/>
         <permission table="ca_entities" bundle="ca_attribute_languageAffiliation" access="edit"/>
         <permission table="ca_entities" bundle="lifespan" access="edit"/>
@@ -62391,6 +61858,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_ImageNotes" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_JobDates" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Requirements" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_SizeOrDuration" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_TreatmentSummary" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_Video" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_WordReference" access="edit"/>
@@ -62413,6 +61881,13 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_conservation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_conservation_request" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_country" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_condition_rating" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_materials" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_recommendations_types" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_cr_treatment_details" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dataGeneralizations" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcBibCitation" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dcLanguage" access="edit"/>
@@ -62421,6 +61896,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission table="ca_occurrences" bundle="ca_attribute_dcType" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dctermscreated" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_description" access="edit"/>
+        <permission table="ca_occurrences" bundle="ca_attribute_detailsCondition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_disposition" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_distanceFromLocality" access="edit"/>
         <permission table="ca_occurrences" bundle="ca_attribute_dynamicProperties" access="edit"/>
@@ -62887,54 +62363,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
       <description>System administrators</description>
       <roles>
         <role>Administrator</role>
-        <role>az_cataloguer</role>
       </roles>
-    </group>
-    <group code="cataloguer">
-      <name>Cataloguers</name>
-      <description>Users who can add and edit catalogue entries</description>
-      <roles>
-        <role>az_cataloguer</role>
-      </roles>
-    </group>
-    <group code="anthropology">
-      <name>Anthropology</name>
-      <description>A group for cataloguers of the Anthropology collection</description>
-      <roles/>
-    </group>
-    <group code="conservators">
-      <name>Conservators</name>
-      <description>Users in this group are conservators.</description>
-      <roles/>
-    </group>
-    <group code="arachnology">
-      <name>Arachnology &amp; Myriapods</name>
-      <description>A group for cataloguers of the Arachnology and Myriapods database</description>
-      <roles>
-        <role>az_cataloguer</role>
-      </roles>
-    </group>
-    <group code="crustacea">
-      <name>Crustacea</name>
-      <description>A group for cataloguers of the Crustacea database</description>
-      <roles>
-        <role>az_cataloguer</role>
-      </roles>
-    </group>
-    <group code="mineralogy">
-      <name>Minerals</name>
-      <description>A group for curators of the minerals databases</description>
-      <roles/>
-    </group>
-    <group code="invert_palaeo">
-      <name>Invertebrate Palaeontology</name>
-      <description/>
-      <roles/>
-    </group>
-    <group code="vertebrate_palaeo">
-      <name>Vertebrate Palaeontology</name>
-      <description/>
-      <roles/>
     </group>
     <group code="Anthrop_Catalogue">
       <name>CMIS Anthropology Catalogue</name>
@@ -63265,9 +62694,6 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
       <userAccess>
         <permission user="administrator" access="edit"/>
       </userAccess>
-      <groupAccess>
-        <permission group="anthropology" access="read"/>
-      </groupAccess>
       <bundlePlacements>
         <placement code="ca_collections_idno">
           <bundle>ca_collections.idno</bundle>
@@ -63511,8 +62937,6 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission user="administrator" access="edit"/>
       </userAccess>
       <groupAccess>
-        <permission group="arachnology" access="read"/>
-        <permission group="crustacea" access="read"/>
         <permission group="admin" access="edit"/>
       </groupAccess>
       <bundlePlacements>
@@ -63730,6 +63154,44 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         </placement>
       </bundlePlacements>
     </display>
+    <display code="display_7" type="ca_objects" system="1">
+      <labels>
+        <label locale="en_AU">
+          <name>Palaeontology Search Display</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="show_empty_values">1</setting>
+      </settings>
+      <userAccess>
+        <permission user="administrator" access="edit"/>
+      </userAccess>
+      <groupAccess>
+        <permission group="admin" access="edit"/>
+        <permission group="Palaeont_Catalogue" access="read"/>
+        <permission group="Palaeont_Curate" access="read"/>
+        <permission group="Palaeont_View" access="read"/>
+      </groupAccess>
+      <bundlePlacements>
+        <placement code="ca_objects_idno">
+          <bundle>ca_objects.idno</bundle>
+        </placement>
+        <placement code="ca_objects_determinationPlantsInverts">
+          <bundle>ca_objects.determinationPlantsInverts</bundle>
+          <settings>
+            <setting name="format"/>
+            <setting name="filter"/>
+          </settings>
+        </placement>
+        <placement code="ca_storage_locations">
+          <bundle>ca_storage_locations</bundle>
+          <settings>
+            <setting name="format"/>
+            <setting name="hierarchy_order">ASC</setting>
+          </settings>
+        </placement>
+      </bundlePlacements>
+    </display>
     <display code="places" type="ca_places" system="1">
       <labels>
         <label locale="en_AU">
@@ -63742,9 +63204,6 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
       <userAccess>
         <permission user="administrator" access="edit"/>
       </userAccess>
-      <groupAccess>
-        <permission group="cataloguer" access="read"/>
-      </groupAccess>
       <bundlePlacements>
 </bundlePlacements>
     </display>
@@ -63761,7 +63220,6 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         <permission user="administrator" access="edit"/>
       </userAccess>
       <groupAccess>
-        <permission group="cataloguer" access="read"/>
         <permission group="admin" access="read"/>
       </groupAccess>
       <bundlePlacements>
@@ -64180,7 +63638,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         </placement>
       </bundlePlacements>
     </searchForm>
-    <searchForm code="cultrual" type="ca_objects" system="1">
+    <searchForm code="cultrual" type="ca_objects" system="0">
       <labels>
         <label locale="en_AU">
           <name>Cultural Heritage Advanced Search</name>
@@ -64189,11 +63647,10 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
       <settings>
         <setting name="form_width">3</setting>
       </settings>
-      <userAccess>
-        <permission user="administrator" access="edit"/>
-      </userAccess>
       <groupAccess>
-        <permission group="anthropology" access="read"/>
+        <permission group="Anthrop_Catalogue" access="read"/>
+        <permission group="Anthrop_Curate" access="read"/>
+        <permission group="Anthrop_View" access="read"/>
       </groupAccess>
       <bundlePlacements>
         <placement code="p48">
@@ -64318,7 +63775,7 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
         </placement>
       </bundlePlacements>
     </searchForm>
-    <searchForm code="dwc" type="ca_objects" system="1">
+    <searchForm code="dwc" type="ca_objects" system="0">
       <labels>
         <label locale="en_AU">
           <name>Zoology Search form</name>
@@ -64327,12 +63784,18 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
       <settings>
         <setting name="form_width">3</setting>
       </settings>
-      <userAccess>
-        <permission user="administrator" access="edit"/>
-      </userAccess>
       <groupAccess>
-        <permission group="arachnology" access="read"/>
-        <permission group="crustacea" access="read"/>
+        <permission group="admin" access="edit"/>
+        <permission group="Vertebrate_View" access="read"/>
+        <permission group="Entom_Catalogue" access="read"/>
+        <permission group="Entom_Curate" access="read"/>
+        <permission group="Entom_View" access="read"/>
+        <permission group="Ichthy_Catalogue" access="read"/>
+        <permission group="Ichthy_Curate" access="read"/>
+        <permission group="Ichthy_View" access="read"/>
+        <permission group="Malac_Catalogue" access="read"/>
+        <permission group="Malac_Curate" access="read"/>
+        <permission group="Malac_View" access="read"/>
       </groupAccess>
       <bundlePlacements>
         <placement code="p61">
@@ -64402,6 +63865,76 @@ Borrowed from: &lt;unit relativeTo="ca_loans"&gt;&#13;
           <bundle>ca_list_item_labels.name_plural</bundle>
           <settings>
             <setting name="label" locale="en_AU">Scientific name</setting>
+            <setting name="width">100px</setting>
+          </settings>
+        </placement>
+      </bundlePlacements>
+    </searchForm>
+    <searchForm code="default" type="ca_objects" system="0">
+      <labels>
+        <label locale="en_AU">
+          <name>Palaeontology Search Form</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="form_width">3</setting>
+      </settings>
+      <userAccess>
+        <permission user="administrator" access="edit"/>
+      </userAccess>
+      <groupAccess>
+        <permission group="admin" access="edit"/>
+        <permission group="Palaeont_Catalogue" access="read"/>
+        <permission group="Palaeont_Curate" access="read"/>
+        <permission group="Palaeont_View" access="read"/>
+      </groupAccess>
+      <bundlePlacements>
+        <placement code="p75">
+          <bundle>ca_objects.idno</bundle>
+          <settings>
+            <setting name="label" locale="en_AU">Specimen Identifier</setting>
+            <setting name="width">100px</setting>
+          </settings>
+        </placement>
+        <placement code="p76">
+          <bundle>ca_place_labels.name</bundle>
+          <settings>
+            <setting name="label" locale="en_AU">Named Places</setting>
+            <setting name="width">100px</setting>
+          </settings>
+        </placement>
+        <placement code="p77">
+          <bundle>ca_storage_locations.idno</bundle>
+          <settings>
+            <setting name="label" locale="en_AU">Storage Location</setting>
+            <setting name="width">100px</setting>
+          </settings>
+        </placement>
+        <placement code="p78">
+          <bundle>ca_objects.lithostratigraphic_provenance</bundle>
+          <settings>
+            <setting name="label" locale="en_AU"/>
+            <setting name="width">100px</setting>
+          </settings>
+        </placement>
+        <placement code="p79">
+          <bundle>ca_objects.GeologicalContext</bundle>
+          <settings>
+            <setting name="label" locale="en_AU"/>
+            <setting name="width">100px</setting>
+          </settings>
+        </placement>
+        <placement code="p80">
+          <bundle>ca_entity_labels.displayname</bundle>
+          <settings>
+            <setting name="label" locale="en_AU">Collector</setting>
+            <setting name="width">100px</setting>
+          </settings>
+        </placement>
+        <placement code="p81">
+          <bundle>ca_objects.determinationPlantsInverts</bundle>
+          <settings>
+            <setting name="label" locale="en_AU"/>
             <setting name="width">100px</setting>
           </settings>
         </placement>

--- a/install/profiles/xml/wamcmis.xml
+++ b/install/profiles/xml/wamcmis.xml
@@ -21862,12 +21862,6 @@ Display in stable environment  Temperature ??°C ± ?°C seasonally, ± ?°C d
       </labels>
       <typeRestrictions>
         <restriction type="DarwinCore"/>
-        <restriction type=""/>
-        <restriction type=""/>
-        <restriction type=""/>
-        <restriction type=""/>
-        <restriction type=""/>
-        <restriction type=""/>
       </typeRestrictions>
       <screens>
         <screen idno="record_level" default="1">
@@ -24530,12 +24524,6 @@ Loaned to: &lt;unit relativeTo="ca_loans"&gt;&#13;
           </labels>
           <typeRestrictions>
             <restriction type="anthropology"/>
-            <restriction type=""/>
-            <restriction type=""/>
-            <restriction type=""/>
-            <restriction type=""/>
-            <restriction type=""/>
-            <restriction type=""/>
           </typeRestrictions>
           <bundlePlacements>
             <placement code="item_status_id1">


### PR DESCRIPTION
- Added `phone_types` list and use in metadata element.
- No longer require a value for Georeference Verification Status.
- Simplify restrictions now based on parent object type instead of multiple child types.
- UI changes - field widths and types, label changes, etc.
- Remove empty restriction types.
- Add "not set" for Direction field.
- Add Distance from Location, Associated Media to EPS object UI.
- Move Colour Negative from `conservation` to `conservation_job`.
- Allow Geological Context to be used in search form and display.
- Change restrictions for Depth In Deposit field.
- Add Date Identified to `vertebrate_paleontology` UI.
- Move Storage Location Notes, Locality, Lithostratigraphic Provenance to parent EPS type UI.
- Add Internal Organisation element for Organisation objects.
- Screen changes - order of elements, element settings.
- Remove permissions for groups which no longer exist.
- Remove roles and groups which no longer exist.
- Amend / add permissions for new roles / groups.
