### PR TITLE
Profile update20141212

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   # Create setup.php
   - ln -s .travis.setup.php setup.php
   # Install the WAM CMIS profile
-  - support/bin/caUtils install --hostname=localhost --setup="$(pwd)/tests/setup-tests.php" --skip-roles --profile-name=$PROFILE --admin-email=dev@gaiaresources.com.au >install.log
+  - support/bin/caUtils install --hostname=localhost --setup="$(pwd)/tests/setup-tests.php" --skip-roles --profile-name=$PROFILE --admin-email=dev@gaiaresources.com.au
 
 before_script:
   # Go into the tests directory to run the tests


### PR DESCRIPTION
Update to installation profile for EPS …
- Adding eventDate to EPS records and subtypes
- Adding new measurement types for history
- Removing unused settings from attributes that changed type
- Update to a suite of lists
  - Anthropology Classification
  - History Classification
  - AZ/TZ
    - Collection Method
  - Preparation Types
  - add occurrenceDetails to simpson and mdc object types
  - Removing taxonRank attribute - taxonRank is now this list item type of the name
  - Change renderer for associatedTaxa to lookup (horizontal hierarchy browser was running out of memory
  - Geological Context now line breaks after 1 element
  - Allow more than 1 recommendation on conservation records
  - Fix typo in StorageType
  - Adding scientific_name_editor to all scientific name types (ranks)
  - Adding additional donor information in the bundle display - includes address and biography between <more> tags
  - A number of fields from the history migration
  - Update ACL permissions for roles
  - Add role for new museum view
  - Add palaontology_display with fields in it for bulk editing

Minor profile tweaks …
- fix profile so that it is valid
- Also remove a number of permissions for ca_attribute_taxonRank as that is no longer used.
- Adding en_AU locale UI labels
