### PR TITLE
Fix search indexing

### DIFF
--- a/app/lib/core/Search/SearchIndexer.php
+++ b/app/lib/core/Search/SearchIndexer.php
@@ -857,7 +857,7 @@ if (!$vb_can_do_incremental_indexing || $pb_reindex_mode) {
 										if (((isset($va_rel_field_info['INDEX_AS_IDNO']) && $va_rel_field_info['INDEX_AS_IDNO']) || in_array('INDEX_AS_IDNO', $va_rel_field_info)) && method_exists($t_rel, "getIDNoPlugInInstance") && ($o_idno = $t_rel->getIDNoPlugInInstance())) {
 											// specialized identifier (idno) processing; used IDNumbering plugin to generate searchable permutations of identifier
 											$va_values = $o_idno->getIndexValues($vs_fld_data);
-											$this->opo_engine->indexField($pn_subject_tablenum, 'I'.$this->opo_datamodel->getFieldNum($vs_related_table, $vs_rel_field), $qr_res->get($vs_related_pk), join(" ", $va_values), array_merge($va_rel_field_info, array('relationship_type_id' => $vn_rel_type_id)));
+											$this->opo_engine->indexField($vn_related_tablenum, 'I'.$this->opo_datamodel->getFieldNum($vs_related_table, $vs_rel_field), $qr_res->get($vs_related_pk), join(" ", $va_values), array_merge($va_rel_field_info, array('relationship_type_id' => $vn_rel_type_id)));
 										} else {
 											// regular intrinsic
 											$this->opo_engine->indexField($vn_related_tablenum, 'I'.$this->opo_datamodel->getFieldNum($vs_related_table, $vs_rel_field), $qr_res->get($vs_related_pk), $vs_fld_data, array_merge($va_rel_field_info, array('relationship_type_id' => $vn_rel_type_id)));

--- a/app/lib/core/Search/SearchIndexer.php
+++ b/app/lib/core/Search/SearchIndexer.php
@@ -585,7 +585,8 @@ class SearchIndexer extends SearchBase {
 						$this->opo_engine->indexField($pn_subject_tablenum, 'I'.$vn_fld_num, $pn_subject_row_id, join(" ", $va_values), $va_data);
 						continue;
 					}
-					
+					// Set the content field to null
+					$pn_content = null;
 					$va_field_list = $t_subject->getFieldsArray();
 					if(in_array($va_field_list[$vs_field]['FIELD_TYPE'],array(FT_DATERANGE,FT_HISTORIC_DATERANGE))) {
 						// if the field is a daterange type get content from start and end fields


### PR DESCRIPTION
- Empty a variable that can possibly be initialised in a loop
  - This lead to incorrect records being indexed on the objects.
- Port fix from upstream where the related table information was not being indexed
