### PR TITLE
Actually reset the types to the root type in the menu

### DIFF
--- a/app/plugins/wamMenu/wamMenuPlugin.php
+++ b/app/plugins/wamMenu/wamMenuPlugin.php
@@ -26,6 +26,8 @@
  * ----------------------------------------------------------------------
  */
 
+require_once(__CA_LIB_DIR__."/core/Datamodel.php");
+
 /**
  * The WAM menu Plugin manipulates the navigation menu to the Museum's use case
  */
@@ -72,6 +74,28 @@ class wamMenuPlugin extends BaseApplicationPlugin {
 	private function _reinstateFindAllObjectTypes( &$pa_menu_bar ) {
 		if ( isset( $pa_menu_bar['find']['navigation']['objects']['requires']['configuration:!ca_objects_breakout_find_by_type_in_menu'] ) ) {
 			unset ( $pa_menu_bar['find']['navigation']['objects']['requires']['configuration:!ca_objects_breakout_find_by_type_in_menu'] );
+			$vo_dm = Datamodel::load();
+			/** @var BaseModelWithAttributes $t_subject */
+			$t_subject = $vo_dm->getInstanceByTableName('ca_objects', true);
+			$t_list = new ca_lists();
+			$t_list->load(array('list_code' => $t_subject->getTypeListCode()));
+
+			$vn_root_id = $t_list->getRootItemIDForList($t_subject->getTypeListCode());
+			$t_list_item = new ca_list_items();
+			$t_list_item->load(array('list_id' => $t_list->getPrimaryKey(), 'parent_id' => null));
+
+			$vs_persistent_search = '';
+			if ($this->getRequest()->isLoggedIn()) {
+				$vs_persistent_search = $this->getRequest()->user->getPreference( 'persistent_search' );
+			}
+			$va_parameters = array(
+				'type_id' => array($vn_root_id),
+				'reset' => array($vs_persistent_search),
+			);
+			$pa_menu_bar['find']['navigation']['objects']['parameters'] = $va_parameters;
+			foreach($pa_menu_bar['find']['navigation']['objects']['submenu']['navigation'] as $vs_menu_key => $va_menu_item){
+				$pa_menu_bar['find']['navigation']['objects']['submenu']['navigation'][$vs_menu_key]['parameters'] = $va_parameters;
+			}
 		}
 	}
 

--- a/app/plugins/wamMenu/wamMenuPlugin.php
+++ b/app/plugins/wamMenu/wamMenuPlugin.php
@@ -88,13 +88,17 @@ class wamMenuPlugin extends BaseApplicationPlugin {
 			if ($this->getRequest()->isLoggedIn()) {
 				$vs_persistent_search = $this->getRequest()->user->getPreference( 'persistent_search' );
 			}
-			$va_parameters = array(
-				'type_id' => array($vn_root_id),
-				'reset' => array($vs_persistent_search),
+			// parent level items require the 'string:' prefix as they get parsed by AppNavigation::_parseParameterValue()
+			$pa_menu_bar['find']['navigation']['objects']['parameters'] = array(
+				'type_id' => 'string:' . $vn_root_id,
+				'reset' => 'string:' . $vs_persistent_search,
 			);
-			$pa_menu_bar['find']['navigation']['objects']['parameters'] = $va_parameters;
+			$va_parameters = array(
+				'type_id' => $vn_root_id,
+				'reset' => $vs_persistent_search,
+			);
 			foreach($pa_menu_bar['find']['navigation']['objects']['submenu']['navigation'] as $vs_menu_key => $va_menu_item){
-				$pa_menu_bar['find']['navigation']['objects']['submenu']['navigation'][$vs_menu_key]['parameters'] = $va_parameters;
+				$pa_menu_bar['find']['navigation']['objects']['submenu']['navigation'][$vs_menu_key]['parameters'] =  $va_parameters;
 			}
 		}
 	}


### PR DESCRIPTION
- The previous change just re-enabled the old menu item
- This commit sets the context to the root object type so all object types can be found
