### PR TITLE
Backport NOJIRA Fix ElasticSearch event logging

### DIFF
--- a/app/lib/core/Plugins/SearchEngine/ElasticSearch.php
+++ b/app/lib/core/Plugins/SearchEngine/ElasticSearch.php
@@ -684,16 +684,15 @@ class WLPlugSearchEngineElasticSearch extends BaseSearchPlugin implements IWLPlu
 				$va_key[0]."/".$va_key[2]
 			);
 
-			$vo_http_client->setRawData(json_encode($va_post_json))->setEncType('text/json')->request('POST');
 			try {
+				$vo_http_client->setRawData(json_encode($va_post_json))->setEncType('text/json')->request('POST');
 				$vo_http_response = $vo_http_client->request();
-				$va_response = json_decode($vo_http_response->getBody(),true);
-				
-				if(!isset($va_response["ok"]) || $va_response["ok"]!=1){
-					caLogEvent('ERR', _t('Indexing commit failed for %1; response was %2', $vs_key, $vo_http_response->getBody()), 'ElasticSearch->flushContentBuffer()');
+
+				if($vo_http_response->getStatus() != 200) {
+					caLogEvent('ERR', _t('Indexing commit failed for %1; response was %2; request was %3', $vs_key, $vo_http_response->getBody(), json_encode($va_post_json)), 'ElasticSearch->flushContentBuffer()');
 				}
 			} catch (Exception $e){
-				caLogEvent('ERR', _t('Indexing commit failed for %1: %2; response was %3', $vs_key, $e->getMessage(), $vo_http_response->getBody()), 'ElasticSearch->flushContentBuffer()');
+				caLogEvent('ERR', _t('Indexing commit failed for %1 with Exception: %2', $vs_key, $e->getMessage()), 'ElasticSearch->flushContentBuffer()');
 			}
 		}
 		


### PR DESCRIPTION
Catch ElasticSearch exceptions rather than just dieing. Just cherry picking https://github.com/collectiveaccess/providence/commit/d6a779c5415a5ef0f106afafc2545264022634cf

They removed the hardcoded ok: true in their responses a while ago:
https://github.com/elasticsearch/elasticsearch/issues/4310

We now use HTTP status codes to determine if everything went ok. We
also catch all exceptions now. Before the whole application would just
barf if ElasticSearch went away.
