### PR TITLE
Make hierarchy browsers full width

### DIFF
--- a/themes/default/css/_hierarchyBrowser.scss
+++ b/themes/default/css/_hierarchyBrowser.scss
@@ -11,7 +11,6 @@ div.hierarchyBrowseTab,
 }
 
 
-
 .hierarchyBrowserLevel li {
 	line-height: 1.2;
 	margin-bottom: 5px;

--- a/themes/default/css/_hierarchyBrowser.scss
+++ b/themes/default/css/_hierarchyBrowser.scss
@@ -4,8 +4,10 @@
 
 
 
-.hierarchyBrowserContainer {
-	width: 100%;
+.hierarchyBrowserContainer,
+div.hierarchyBrowseTab,
+.caRelatedItem>div:nth-child(2){
+	width: 100% !important;
 }
 
 

--- a/themes/default/css/local.css
+++ b/themes/default/css/local.css
@@ -156,8 +156,10 @@ div.roundedRel {
   div.roundedRel a {
     font-size: inherit; }
 
-.hierarchyBrowserContainer {
-  width: 100%; }
+.hierarchyBrowserContainer,
+div.hierarchyBrowseTab,
+.caRelatedItem > div:nth-child(2) {
+  width: 100% !important; }
 
 .hierarchyBrowserLevel li {
   line-height: 1.2;


### PR DESCRIPTION
- Upstream currently hardcodes these to 700px via `style` attribute, so  it necessary to user  !important
