### PR TITLE
Limit the number of rows to process in a single cron job

### DIFF
--- a/app/plugins/wamMaterialisedTaxonomy/conf/materialisedTaxonomy.conf
+++ b/app/plugins/wamMaterialisedTaxonomy/conf/materialisedTaxonomy.conf
@@ -4,6 +4,9 @@ enabled = 1
 # Skip rows which have already been processed for the given set of input values
 skip_processed_rows = 1
 
+# Limit of the number of rows to process at a time
+rows_to_process = 5000
+
 # List of tables and types and subtypes with mapping of type idno to attribute name
 tables = {
 	ca_list_items = {


### PR DESCRIPTION
- Plugin only updates rows if they have changed
- This change makes sure this job doesn't go on too long, leaving the remainder of rows for future cron jobs
