### PR TITLE
#151 Fix access to favicon.ico and .eot font files.

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -2,14 +2,14 @@ Order allow,deny
 Allow from all
 
 <FilesMatch ".*\.[A-Za-z0-9]+">
-	Deny from all
+    Deny from all
 </FilesMatch>
 <FilesMatch "^(index\.php)?$">
-        Allow from all
+    Allow from all
 </FilesMatch>
 <FilesMatch "^(index|service|tilepic)\.php$">
-        Allow from all
+    Allow from all
 </FilesMatch>
-<FilesMatch "^.*\.(css|gif|jpg|png|js|woff|ttf|swf|map)$">
-        Allow from all
+<FilesMatch "^.*\.(css|gif|jpg|png|ico|js|woff|ttf|eot|swf|map)$">
+    Allow from all
 </FilesMatch>


### PR DESCRIPTION
The file extensions just needed to be added to the whitelist in the root-level .htaccess file.

This is possibly fixed upstream in 1.5 but I can deal with that in the merge.  I fixed this while I was waiting for the database to import to my local machine, because I saw the bug and figured it would be easy to fix (it was).
