### PR TITLE
Support container element ID attribute for bundle placements.

### DIFF
--- a/app/lib/ca/BundlableLabelableBaseModelWithAttributes.php
+++ b/app/lib/ca/BundlableLabelableBaseModelWithAttributes.php
@@ -1763,6 +1763,7 @@ class BundlableLabelableBaseModelWithAttributes extends LabelableBaseModelWithAt
 		$vs_output = str_replace("^ERRORS", join('; ', $va_errors), $vs_output);
 		$vs_output = str_replace("^LABEL", $vs_label, $vs_output);
 		$vs_output = str_replace("^DOCUMENTATIONLINK", $vs_documentation_link, $vs_output);
+		$vs_output = str_replace("^CONTAINERID", $ps_placement_code . $pa_options['formName'] . "_container", $vs_output);
 
 		$ps_bundle_label = $vs_label_text;
 		


### PR DESCRIPTION
- The template now supports `^CONTAINERID`, which is replaced by a value
  equal to the existing ID attribute of the child container, which contains only
  the form field and not the label, plus "_container".
