### PR TITLE
Support `css_classes` placement setting.

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -615,9 +615,9 @@ form_element_display_format_without_label = <div class='formLabel'>^ELEMENT</div
 form_element_error_display_format = <div class='formLabel'>^EXTRA^LABEL (<span class='formLabelError'>^ERRORS</span>)<br/>^ELEMENT</div>
 
 # Used for bundle-able fields such as attributes
-bundle_element_display_format = <div class='bundleLabel'>^LABEL ^DOCUMENTATIONLINK ^ELEMENT</div>
+bundle_element_display_format = <div class='bundleLabel ^CSSCLASSES'>^LABEL ^DOCUMENTATIONLINK ^ELEMENT</div>
 bundle_element_display_format_without_label = <div class='formLabel'>^ELEMENT</div>
-bundle_element_error_display_format = <div class='bundleLabel'>^LABEL (<span class='bundleLabelError'>^ERRORS</span>)<br/>^ELEMENT</div>
+bundle_element_error_display_format = <div class='bundleLabel ^CSSCLASSES'>^LABEL (<span class='bundleLabelError'>^ERRORS</span>)<br/>^ELEMENT</div>
 
 # Used for the 'idno' field of bundle-providers (Eg. ca_objects, ca_places, etc.)
 idno_element_display_format = <div class='formLabel'>^LABEL<br/>^ELEMENT <span id='idnoStatus'></span></div>

--- a/app/lib/ca/BundlableLabelableBaseModelWithAttributes.php
+++ b/app/lib/ca/BundlableLabelableBaseModelWithAttributes.php
@@ -1763,6 +1763,7 @@ class BundlableLabelableBaseModelWithAttributes extends LabelableBaseModelWithAt
 		$vs_output = str_replace("^ERRORS", join('; ', $va_errors), $vs_output);
 		$vs_output = str_replace("^LABEL", $vs_label, $vs_output);
 		$vs_output = str_replace("^DOCUMENTATIONLINK", $vs_documentation_link, $vs_output);
+		$vs_output = str_replace("^CSSCLASSES", (isset($pa_bundle_settings['css_classes']) ? $pa_bundle_settings['css_classes'] : ''), $vs_output);
 
 		$ps_bundle_label = $vs_label_text;
 		

--- a/app/models/ca_editor_ui_bundle_placements.php
+++ b/app/models/ca_editor_ui_bundle_placements.php
@@ -80,6 +80,15 @@ $_ca_editor_ui_bundle_placement_settings = array(		// global
 		'label' => _t('Height'),
 		'description' => _t('Width, in characters or pixels, of search form elements.')
 	),
+	'css_classes' => array(
+		'formatType' => FT_TEXT,
+		'displayType' => DT_FIELD,
+		'width' => 30, 'height' => 1,
+		'takesLocale' => false,
+		'default' => '',
+		'label' => _t('CSS Classes'),
+		'description' => _t('CSS classes to apply to form elements.')
+	),
 	'readonly' => array(
 		'formatType' => FT_NUMBER,
 		'displayType' => DT_CHECKBOXES,


### PR DESCRIPTION
- Add definition in model class.
- Add call to `str_replace()` in renderer.
- Add to default template in `app.conf`.

With this change, the admin user can specify (by typing) any number of CSS classes to add to the bundle placement's outermost container element.  The `bundleLabel` class is hardcoded and cannot be removed.
