### PR TITLE
NOJIRA Fix reporting of skipped rows and groupings

### DIFF
--- a/app/models/ca_data_importers.php
+++ b/app/models/ca_data_importers.php
@@ -1702,7 +1702,10 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 						}
 					
 						if (!sizeof($va_vals)) { $va_vals = array(0 => null); }	// consider missing values equivalent to blanks
-				
+
+						// Get location in content tree for addition of new content
+						$va_item_dest = explode(".",  $va_item['destination']);
+						$vs_item_terminal = $va_item_dest[sizeof($va_item_dest)-1];
 						// Do value conversions
 						foreach($va_vals as $vn_i => $vm_val) {
 							// Evaluate skip-if-empty options before setting default value, addings prefix/suffix or formatting with templates


### PR DESCRIPTION
- value of $vs_item_dest is not set reliably, which leads to incorrect reporting about skipped rows, groups and mappings
