### PR TITLE
Dont force text attribute values to have strange width and height

### DIFF
--- a/app/lib/ca/Attributes/Values/TextAttributeValue.php
+++ b/app/lib/ca/Attributes/Values/TextAttributeValue.php
@@ -280,13 +280,14 @@
  			$vs_height = trim((isset($pa_options['height']) && $pa_options['height'] > 0) ? $pa_options['height'] : $va_settings['fieldHeight']);
  			$vs_class = trim((isset($pa_options['class']) && $pa_options['class']) ? $pa_options['class'] : '');
 			$vs_element = '';
- 			
- 			if (!preg_match("!^[\d\.]+px$!i", $vs_width)) {
- 				$vs_width = ((int)$vs_width * 6)."px";
- 			}
- 			if (!preg_match("!^[\d\.]+px$!i", $vs_height)) {
- 				$vs_height = ((int)$vs_height * 16)."px";
- 			}
+
+// 			Disabling this as we'll either set the width as px values or use classes for elements
+// 			if (!preg_match("!^[\d\.]+px$!i", $vs_width)) {
+// 				$vs_width = ((int)$vs_width * 6)."px";
+// 			}
+// 			if (!preg_match("!^[\d\.]+px$!i", $vs_height)) {
+// 				$vs_height = ((int)$vs_height * 16)."px";
+// 			}
  			
  			if ($va_settings['usewysiwygeditor']) {
  				$o_config = Configuration::load();

--- a/app/lib/ca/Attributes/Values/TextAttributeValue.php
+++ b/app/lib/ca/Attributes/Values/TextAttributeValue.php
@@ -68,7 +68,7 @@
 		'fieldWidth' => array(
 			'formatType' => FT_NUMBER,
 			'displayType' => DT_FIELD,
-			'default' => 40,
+			'default' => '',
 			'width' => 5, 'height' => 1,
 			'label' => _t('Width of data entry field in user interface'),
 			'description' => _t('Width, in characters, of the field when displayed in a user interface.')
@@ -76,7 +76,7 @@
 		'fieldHeight' => array(
 			'formatType' => FT_NUMBER,
 			'displayType' => DT_FIELD,
-			'default' => 1,
+			'default' => '',
 			'width' => 5, 'height' => 1,
 			'label' => _t('Height of data entry field in user interface'),
 			'description' => _t('Height, in characters, of the field when displayed in a user interface.')
@@ -282,12 +282,12 @@
 			$vs_element = '';
 
 // 			Disabling this as we'll either set the width as px values or use classes for elements
-// 			if (!preg_match("!^[\d\.]+px$!i", $vs_width)) {
-// 				$vs_width = ((int)$vs_width * 6)."px";
-// 			}
-// 			if (!preg_match("!^[\d\.]+px$!i", $vs_height)) {
-// 				$vs_height = ((int)$vs_height * 16)."px";
-// 			}
+ 			if (!preg_match("!^[\d\.]+px$!i", $vs_width) && $vs_width) {
+ 				$vs_width = ((int)$vs_width * 6)."px";
+ 			}
+ 			if (!preg_match("!^[\d\.]+px$!i", $vs_height) && $vs_height) {
+ 				$vs_height = ((int)$vs_height * 16)."px";
+ 			}
  			
  			if ($va_settings['usewysiwygeditor']) {
  				$o_config = Configuration::load();

--- a/app/lib/ca/Attributes/Values/TextAttributeValue.php
+++ b/app/lib/ca/Attributes/Values/TextAttributeValue.php
@@ -281,7 +281,6 @@
  			$vs_class = trim((isset($pa_options['class']) && $pa_options['class']) ? $pa_options['class'] : '');
 			$vs_element = '';
 
-// 			Disabling this as we'll either set the width as px values or use classes for elements
  			if (!preg_match("!^[\d\.]+px$!i", $vs_width) && $vs_width) {
  				$vs_width = ((int)$vs_width * 6)."px";
  			}


### PR DESCRIPTION
~~This includes https://github.com/wamuseum/providence/pull/212 and that should be merged first.~~
- The input fields were all looking really strange. It also doesn't make sense to set a width / height without a unit, and harcoding 16 px to be a single row and 6 px to be a single character just didn't make sense. 
- We will still be able to override them using either new classes or setting the values to be px values

Before:
![before](https://cloud.githubusercontent.com/assets/12571/11950190/234f7990-a8c1-11e5-98e0-39dce4860e69.png)

After:
![detailsafter](https://cloud.githubusercontent.com/assets/12571/11950192/28bd9524-a8c1-11e5-9c28-a18438a55826.png)
