### PR TITLE
PROV-1443 Fix Too many permissions make roles not save

### DIFF
--- a/app/version.php
+++ b/app/version.php
@@ -3,7 +3,7 @@
 	define('__CollectiveAccess__', '1.5.1');
 	
 	# Schema revision
-	define('__CollectiveAccess_Schema_Rev__', 121);
+	define('__CollectiveAccess_Schema_Rev__', 122);
 	
 	# Release type
 	define('__CollectiveAccess_Release_Type__', 'GIT');

--- a/install/inc/schema_mysql.sql
+++ b/install/inc/schema_mysql.sql
@@ -1376,8 +1376,8 @@ create table ca_user_roles
    code                           varchar(20)                    not null,
    description                    text                           not null,
    rank                           smallint unsigned              not null default 0,
-   vars                           text                           not null,
-   field_access                   text                           not null,
+   vars                           longtext                       not null,
+   field_access                   longtext                       not null,
    primary key (role_id)
 ) engine=innodb CHARACTER SET utf8 COLLATE utf8_general_ci;
 
@@ -6848,5 +6848,5 @@ create table ca_schema_updates (
 ) engine=innodb CHARACTER SET utf8 COLLATE utf8_general_ci;
 
 /* Indicate up to what migration this schema definition covers */
-/* CURRENT MIGRATION: 121 */
-INSERT IGNORE INTO ca_schema_updates (version_num, datetime) VALUES (121, unix_timestamp());
+/* CURRENT MIGRATION: 122 */
+INSERT IGNORE INTO ca_schema_updates (version_num, datetime) VALUES (122, unix_timestamp());

--- a/support/sql/migrations/122.sql
+++ b/support/sql/migrations/122.sql
@@ -1,0 +1,13 @@
+/*
+	Date: 7 January 2016
+	Migration: 122
+	Description: Use LONGTEXT for `vars` and `field_access` columns in ca_user_roles
+*/
+
+/*==========================================================================*/
+
+ALTER TABLE ca_user_roles MODIFY vars LONGTEXT NOT NULL, MODIFY field_access LONGTEXT NOT NULL;
+
+/* Always add the update to ca_schema_updates at the end of the file */
+# noinspection SqlNoDataSourceInspection
+INSERT IGNORE INTO ca_schema_updates (version_num, datetime) VALUES (122, unix_timestamp());


### PR DESCRIPTION
- Use LONGTEXT for `vars` and `field_access` columns in ca_user_roles
