### PR TITLE
Add support for `trim` function to `ExpressionParser`

### DIFF
--- a/app/lib/core/Parsers/ExpressionParser/ExpressionVisitor.php
+++ b/app/lib/core/Parsers/ExpressionParser/ExpressionVisitor.php
@@ -63,12 +63,15 @@ class ExpressionVisitor implements Visitor\Visit {
 			return array_sum($arguments) / count($arguments);
 		};
 
-
-		$join = function () {
+		$implode = function () {
 			$va_args = func_get_args();
+			if(count($va_args)<2){
+				throw new Exception(_t('Invalid number of arguments. Number of arguments passed: %1', count($va_args)));
+			}
 			$vs_glue = array_shift($va_args);
-			return join($vs_glue, $va_args);
+			return implode($vs_glue, $va_args);
 		};
+
 		$this->opa_functions  = array(
 			'abs'			=> xcallable('abs'),
 			'ceil'			=> xcallable('ceil'),
@@ -95,8 +98,9 @@ class ExpressionVisitor implements Visitor\Visit {
 			'average' 		=> xcallable($average),
 			'avg'     		=> xcallable($average),
 			'sum'			=> xcallable(function () { return array_sum(func_get_args()); }),
-			'join'			=> xcallable($join),
-			'implode'			=> xcallable($join),
+			'join'			=> xcallable($implode),
+			'implode'		=> xcallable($implode),
+			'trim'			=> xcallable('trim'),
 		);
 		return;
 	}

--- a/tests/lib/core/Parsers/ExpressionParserTest.php
+++ b/tests/lib/core/Parsers/ExpressionParserTest.php
@@ -111,6 +111,18 @@ class ExpressionParserTest extends PHPUnit_Framework_TestCase {
 		// date formatting
 		$this->assertRegExp("/^1985\-01\-28T/", ExpressionParser::evaluate('formatdate("1985/01/28")'));
 		$this->assertRegExp("/^1985\-01\-28T/", ExpressionParser::evaluate('formatgmdate("1985/01/28")'));
+
+		// join strings
+		$this->assertEquals('piece1gluepiece2', ExpressionParser::evaluate('join("glue", "piece1", "piece2")'));
+		$this->setExpectedException('Exception', 'Invalid number of arguments. Number of arguments passed: 0');
+		ExpressionParser::evaluate('join()');
+		$this->setExpectedException('Exception', 'Invalid number of arguments. Number of arguments passed: 1');
+		ExpressionParser::evaluate('join("foo")');
+
+		// trim strings
+		$this->assertEquals('spaces', ExpressionParser::evaluate('trim(" spaces ")'));
+		$this->assertEquals('nospaces', ExpressionParser::evaluate('trim("nospaces")'));
+		$this->assertEquals('', ExpressionParser::evaluate('trim("  ")'));
 	}
 
 	/**
@@ -156,6 +168,7 @@ class ExpressionParserTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('test123', ExpressionParser::evaluate('^ca_objects.preferred_labels', array('ca_objects.preferred_labels' => 'test123')));
 		$this->assertEquals('Poa annua', ExpressionParser::evaluate('join(" ", ^Genus, ^Species)', array('Genus' => 'Poa', 'Species' => 'annua')));
 		$this->assertEquals('Poa annua L.', ExpressionParser::evaluate('implode(" ", ^Genus, ^Species, ^Authority)', array('Genus' => 'Poa', 'Species' => 'annua', 'Authority' => 'L.')));
+		$this->assertTrue((bool)ExpressionParser::evaluate('trim(join(" ", ^Genus, ^Species)) = ^ScientificName', array('Genus' => 'Poa', 'Species' => '', 'ScientificName' => 'Poa')));
 	}
 
 	public function testObscureVars() {


### PR DESCRIPTION
Also more consistent whitespace and use the non-aliased function for implode.
