### PR TITLE
Backport fix for mysql data reader from rwahs to make it compatible w…

### DIFF
--- a/app/lib/ca/Import/DataReaders/MySQLDataReader.php
+++ b/app/lib/ca/Import/DataReaders/MySQLDataReader.php
@@ -70,7 +70,7 @@ class MySQLDataReader extends BaseDataReader {
 	 */
 	public function read($ps_source, $pa_options=null) {
 		parent::read($ps_source, $pa_options);
-		
+		$this->config = Configuration::load();
 		# mysql://username:password@localhost/database?table=tablename
 		# or limit the query using
 		# mysql://username:password@localhost/database?table=tablename&limit=100&offset=10
@@ -84,7 +84,7 @@ class MySQLDataReader extends BaseDataReader {
 				"password" => 	$va_url['pass'],
 				"host" =>	 	$va_url['host'],
 				"database" =>	$vs_db,
-				"type" =>		'mysql'
+				"type"     =>   $this->config->get("db_type")
 			));
 			$this->opn_current_row = 0;
 			


### PR DESCRIPTION
…ith php7

* The `mysql` database type uses mysql_connect which has been removed from php7
* This uses the configured value from `setup.php`